### PR TITLE
change shuffle default behaviour

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 0.1.2 (2021-10-05)
+
+### Fixed
+- upgrade @clyde-lang/interpreter to align shuffle behaviour with docs.
+
 ## 0.1.1 (2021-06-04)
 
 ### Fixed
 
-- updrade @clyde-lang/parser to support logical diverts
+- upgrade @clyde-lang/parser to support logical diverts
 
 ## 0.1.0 (2021-02-18)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clyde-lang/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "CLI tool for executing, parsing and debugging Clyde dialogue files",
   "main": "./cjs/index.js",
   "author": "Vinicius Gerevini <viniciusgerevini@gmail.com>",

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -308,9 +308,9 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@clyde-lang/interpreter@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@clyde-lang/interpreter/-/interpreter-0.1.2.tgz#43e5c695e690e4b251dc90ce733c2f4b21eb5061"
-  integrity sha512-BBf9yx1R9LUqYppRpdLNQEc7QltTNy+b9vO7XJGUOtyAOX0eVBhkCDUottQ68VPZKfZYjVU1bSTq+poFWJNEhg==
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@clyde-lang/interpreter/-/interpreter-0.1.3.tgz#0bac6ec3326c1e86db2be665129090e772fe4d62"
+  integrity sha512-6sO0Fh0IVCqG9KHQSHgrfJQ6KZ131Ltqd8GlNOXinK7J5UYlZN01EvSSmo+4cEgF5gEXqA2PhSVbMyZw4Ib9sA==
 
 "@clyde-lang/parser@^0.1.2":
   version "0.1.2"

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,10 +1,10 @@
 {
   "name": "clyde-editor",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "homepage": "./",
   "dependencies": {
-    "@clyde-lang/interpreter": "^0.1.2",
+    "@clyde-lang/interpreter": "^0.1.3",
     "@clyde-lang/parser": "^0.1.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",

--- a/editor/yarn.lock
+++ b/editor/yarn.lock
@@ -1210,15 +1210,15 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@clyde-lang/interpreter@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@clyde-lang/interpreter/-/interpreter-0.1.1.tgz#9691df4e593d9fe63e7c98928a3429eed2ff1ff7"
-  integrity sha512-RDNetIvkXdLeGhdqGeDSa+xQUoRO7aKfYJUDQXg7JTtA0oMo2DM5leOvPwW+6kNF8SuCKmgsdWntycBdr+zi+g==
+"@clyde-lang/interpreter@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@clyde-lang/interpreter/-/interpreter-0.1.3.tgz#0bac6ec3326c1e86db2be665129090e772fe4d62"
+  integrity sha512-6sO0Fh0IVCqG9KHQSHgrfJQ6KZ131Ltqd8GlNOXinK7J5UYlZN01EvSSmo+4cEgF5gEXqA2PhSVbMyZw4Ib9sA==
 
-"@clyde-lang/parser@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@clyde-lang/parser/-/parser-0.1.0.tgz#046a604698eec0fc1d8906cb5d54381ee52e272e"
-  integrity sha512-a6V5W+nItkMVxc9KlxJhh1nLmmjWkwz8trBHm1Q7mUV95wzFCks3LtlHNQzT8fvG+ZOr9N2iw9Z1ZcmNRE364g==
+"@clyde-lang/parser@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@clyde-lang/parser/-/parser-0.1.2.tgz#7c88a716fb665f4cb7fc64daacdc4581fd9cea9c"
+  integrity sha512-lh4APSlpmkCq2CkUFhQoLxgGMRJneh2YVtPSQ91tZS1CuV8TQHA8lOB3rQrtRrGp5ENZ/rxZqCUzz1cMZlqpCA==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"

--- a/interpreter/CHANGELOG.md
+++ b/interpreter/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 0.1.3 (2021-10-05)
+
+### Breaking Changes
+
+Cycle is default variation when using shuffle without explictly declaring mode.
+```
+( shuffle
+    - variation 1
+    - variation 2
+)
+-- is equivalent to
+( shuffle cycle
+    - variation 1
+    - variation 2
+)
+```
+It used to be `sequence`, which is wrong according to the documentation. As the documentation always stated this behaviour, I'll only bump a patch.
+
+
+### Fixed
+
+- fix: shuffle default variation should be "cycle"
+
 ## 0.1.2 (2021-06-04)
 
 ### Fixed

--- a/interpreter/package.json
+++ b/interpreter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clyde-lang/interpreter",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Interpreter for Clyde dialogue language",
   "main": "./cjs/index.js",
   "types": "./types/index.d.ts",

--- a/interpreter/src/interpreter-alternatives.spec.js
+++ b/interpreter/src/interpreter-alternatives.spec.js
@@ -55,8 +55,8 @@ describe("Interpreter: variations", () => {
     expect(dialogue.getContent().text).toEqual('end');
   });
 
-  test.each(['shuffle', 'shuffle sequence'])('%s: run shuffled variations in sequence, sticking with the last one', (mode) => {
-    const content = parse(`( ${mode}\n - Hello!\n - Hi!\n - Hey!\n)\nend\n`);
+  it('shuffle sequence: run shuffled variations in sequence, sticking with the last one', () => {
+    const content = parse(`( shuffle sequence\n - Hello!\n - Hi!\n - Hey!\n)\nend\n`);
     const dialogue = Interpreter(content);
 
     let usedOptions = [];
@@ -86,8 +86,8 @@ describe("Interpreter: variations", () => {
     expect(dialogue.getContent().text).toEqual('end');
   });
 
-  it('shuffle cycle: show each alternative out of order and then repeat again when finished.', () => {
-    const content = parse(`( shuffle cycle\n - Hello!\n - Hi!\n - Hey!\n)\nend\n`);
+  test.each(['shuffle', 'shuffle cycle'])('%s: show each alternative out of order and then repeat again when finished.', (mode) => {
+    const content = parse(`( ${mode}\n - Hello!\n - Hi!\n - Hey!\n)\nend\n`);
     const dialogue = Interpreter(content);
 
     let usedOptions = [];

--- a/interpreter/src/interpreter.js
+++ b/interpreter/src/interpreter.js
@@ -80,7 +80,7 @@ export function Interpreter(doc, data, dictionary = {}) {
       }
       return current;
     },
-    'shuffle': (variations, mode = 'sequence' ) => {
+    'shuffle': (variations, mode = 'cycle' ) => {
       const SHUFFLE_VISITED_KEY = `${variations._index}_shuffle_visited`;
       const LAST_VISITED_KEY = `${variations._index}_last_index`;
       let visitedItems = mem.getInternalVariable(SHUFFLE_VISITED_KEY, []);


### PR DESCRIPTION
When using `shuffle` without  explicitly declaring a mode, as per documentation, it should use `cycle`.
```
( shuffle
    - variation 1
    - variation 2
)
-- is equivalent to
( shuffle cycle
    - variation 1
    - variation 2
)
```
It used to be `sequence`, which is wrong according to the documentation. As the documentation always stated this behaviour, I'll only bump a patch.

