### PR TITLE
Do not show option header by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+
+Check [LANGUAGE.md](./LANGUAGE.md) for latest documentation.
+
+## 2.0.0 (2021-11-21)
+
+### Breaking Changes
+
+- Options won´t print first line as before.
+- Brackets (`[]`) used for display-only options are not supported anymore.
+- To reproduce previous behaviour, options should contain the new display-option symbol (`=`)
+
+Here is a sample on how to fix your dialogues for this new version:
+
+Old way:
+```
++ This will be displayed
+* This will be displayed
+> This will be displayed
+
++ [This won't be displayed]
+  some text...
+* [This won't be displayed]
+  some text...
+> [This won't be displayed]
+  some text...
+```
+New way:
+```
++= This will be displayed
+*= This will be displayed
+>= This will be displayed
+
++ This won't be displayed
+  some text...
+* This won't be displayed
+  some text...
+> This won't be displayed
+  some text...
+```
+
+### Changed
+
+- Changed options default behaviour. (check breaking changes)
+
+## 1.0.0 (2021-10-21)
+
+### Breaking changes
+
+Simple quotes (`'`) can be used for escaping characters. Any sentence starting with it
+will be escaped.
+
+```
+This is a normal non-escaped line $100.
+"This line will be printed as is: ###"
+'This line is supported now and it will be printed as is: ###' -- this is the new change
+```
+
+### Changed
+
+- Simple quotes (`'`) can be used for escaping characters.
+- Simple quotes (`'`) can be used in String variables in logic blocks.
+    - i.e `{ set text = 'this is valid' }`
+
+
+## 0.0.1 (2021-02-17)
+
+Initial release. Check `./LANGUAGE.md` for full documentation.
+

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -2,14 +2,14 @@
 
 Clyde is a language for writing game dialogues. It supports branching dialogues, translations and interfacing with your game through variables and events.
 
-It was heavily inspired by [Ink](https://github.com/inkle/ink), but it focus on dialogues instead of narratives.
+It was heavily inspired by [Ink](https://github.com/inkle/ink), but it focuses on dialogues instead of narratives.
 
 You can play with the online editor [here](https://viniciusgerevini.github.io/clyde/).
 
 ### Principles
 
-- Simple to write. As close to normal text as possible.
-- File as source of truth. No extra databases or random data created during parsing.
+- Simple to write. As close to regular writing as possible.
+- File as the source of truth. No extra databases or random data is created during parsing.
 - Simple API. While other dialogue solutions try to be full game engines, Clyde's goal is to handle dialogues only, providing a simple interface that can be used in different scenarios.
 - Localisation in mind.
 
@@ -21,7 +21,7 @@ Even though this document is focused on the language itself, I think it's a good
 ``` javascript
 const dialogue = Interpreter(dialogueDocument);
 
-// Start or restart the dialogue from the begining. Optional when no block provided.
+// Start or restart the dialogue from the beginning. Optional when no block provided.
 dialogue.start(blockName);
 
 // Listen to events (variable changed, event triggered)
@@ -128,7 +128,7 @@ Output:
 
 ### Grouping lines
 
-If you wan't to group multiple lines in one call, you just need to indent the subsequent lines. You can choose to use spaces or tabs (or even both, however I don't recommend that):
+If you want to group multiple lines in one call, you just need to indent the subsequent lines. You can choose to use spaces or tabs (or even both, however, I don't recommend that):
 
 ```
 This is the first dialogue line.
@@ -147,7 +147,7 @@ Output:
 
 ### Speaker
 
-Use `:` to set a line speaker. Anything from the begining of the line to `:`(colon) is used as speaker.
+Use `:` to set a line speaker. Anything from the beginning of the line to `:`(colon) is used as speaker.
 
 ```
 Hagrid: Harry, yer a wizard.
@@ -229,10 +229,43 @@ Output:
 
 To define options or branches you can use `*` (single use), `+` (sticky) or `>` (fallback).
 
-#### Your options may be single lines:
+### Simple options
 ```
 * yes
+  Let's do this!
 * no
+  Not this time!
+
+continue
+```
+
+Output:
+```javascript
+// get content
+{
+    type: 'options',
+    options: [
+        { label: 'yes' },
+        { label: 'no' },
+    ]
+}
+
+// choose 0
+
+// get content
+{ type: 'line', text: "Let's do this!" }
+
+// get content
+{ type: 'line', text: 'continue'}
+```
+
+#### Your options may be single lines:
+
+By default, option labels are not returned as content. If you want to return a label, you can
+use the option display character `=`:
+```
+*= yes
+*= no
 
 continue
 ```
@@ -262,7 +295,7 @@ Output:
 * I need to think about that
     some line
     some other line
-* Simple option
+*= Simple option
 
 continue
 ```
@@ -281,9 +314,6 @@ Output
 // choose 0
 
 // get content
-{ type: 'line', text: 'I need to think about that'}
-
-// get content
 { type: 'line', text: 'some line'}
 
 // get content
@@ -299,7 +329,7 @@ Options can be nested:
 
 ```
 * Option a - has nested options
-    * Yes
+    *= Yes
     * No
         nope
 *
@@ -324,9 +354,6 @@ Output
 // choose 0
 
 // get content
-{ type: 'line', text: 'Option a - has nested options'}
-
-// get content
 {
     type: 'options',
     options: [
@@ -336,9 +363,6 @@ Output
 }
 
 // choose 1
-
-// get content
-{ type: 'line', text: 'No'}
 
 // get content
 { type: 'line', text: 'Nope'}
@@ -347,42 +371,14 @@ Output
 { type: 'line', text: 'continue'}
 ```
 
-### Display-only text
-
-As you may have noticed, everytime you choose an option, the option label is also returned as a line. You can set the first line as display only by using `[` and `]`
-
-
-```
-* Yes
-* [ No ]
-    nope
-```
-
-Output
-```javascript
-// get content
-{
-    type: 'options',
-    options: [
-        { label: 'Yes' },
-        { label: 'No' }
-    ]
-}
-
-// choose 1
-
-// get content
-{ type: 'line', text: 'nope'}
-```
-
 ### Options list's title
 
-Depending on how you show your dialogue, your options list may lose its context. To prevent that, you can define titles for your option list by indenting its block.
+Depending on how you show your dialogue, your options list may lose its context. To prevent that, you can define titles for your options list by indenting its block.
 
 ```
 Do you like turtles?
-    * Yes
-    * No
+    *= Yes
+    *= No
 ```
 
 Output
@@ -408,9 +404,9 @@ Output
 Option's default behaviour is to be removed from the list once used:
 
 ```
-* [ Option a ]
+* Option a
     A
-* [ Option b ]
+* Option b
     B
 
 ```
@@ -445,9 +441,9 @@ Output
 This is not always the desired behaviour. For that, you can use `+` for sticky options:
 
 ```
-+ [ Option a ]
++ Option a
     A
-* [ Option b ]
+* Option b
     B
 
 ```
@@ -486,9 +482,9 @@ Output
 A fallback option (`>`) is an option that is executed automatically when there is no other option available. When more than one option is available, it behaves like a sticky option.
 
 ```
-* [ Let's talk about it.]
+* Let's talk about it.
     A
-> [ That's all for today. ]
+> That's all for today.
     B
 
 ```
@@ -524,11 +520,11 @@ Nesting content can get messy real quick. An alternative is to group your conten
 
 ```
 What do you want to talk about?
-    * [Life]
+    * Life
       -> talk about life
-    * [The universe]
+    * The universe
       -> talk about the universe
-    * [Everything else...]
+    * Everything else...
       -> talk about everything else
 
 == talk about life
@@ -566,7 +562,7 @@ npc: I don't have time for this...
 { type: 'line', speaker: 'npc', text: "That's too complex!" }
 ```
 
-Blocks also allow you to have multiple dialogues in the same file, and run them independently from each other.
+Blocks also allow you to have multiple dialogues in the same file and run them independently from each other.
 
 ### Divert to parent
 
@@ -574,7 +570,7 @@ You can use `<-` to divert back to the parent block or parent option list.
 
 By default, blocks do not return to their callers.
 
-Because of that, in the following example the `npc: Let's continue...` line will never be called.
+Because of that, in the following example, the `npc: Let's continue...` line will never be called.
 ```
 npc: What do you want to do?
 
@@ -590,7 +586,7 @@ npc: Well! That's too complicated...
 
 ```
 
-In order to keep the progression in the main block, you can use a divert to parent `<-` inside the block.
+To keep the progression in the main block, you should use a divert to parent `<-` inside the block.
 
 ```
 npc: What do you want to do?
@@ -607,25 +603,25 @@ npc: Well! That's too complicated...
 
 ```
 
-Diverts to parent can also be used in options list, to allow the player to go through all options if they wish to.
+Diverts to parent can also be used in the options list, to allow the player to go through all options if they wish to.
 
 ```
 What do you want to talk about?
-    * [Life]
+    * Life
       -> talk about life
       <-
-    * [The universe]
+    * The universe
       -> talk about the universe
       <-
-    * [Everything else...]
+    * Everything else...
       -> talk about everything else
       <-
-    + [Nothing in special]
+    + Nothing in special
         I don't want to talk about anything.
 
 npc: That's all for today!
 
--- blocks defintions after this line
+-- blocks definitions after this line
 
 == talk about life
 player: I want to talk about life!
@@ -643,17 +639,17 @@ npc: I don't have time for this...
 <-
 ```
 
-These diverts can be simplified by joining them into the previous divert:
+You can join both diverts together in the same line for a cleaner look:
 
 ```
 What do you want to talk about?
-    * [Life]
+    * Life
       -> talk about life <-
-    * [The universe]
+    * The universe
       -> talk about the universe <-
-    * [Everything else...]
+    * Everything else...
       -> talk about everything else <-
-    + [Nothing in special]
+    + Nothing in special
         I don't want to talk about anything.
 ```
 
@@ -677,7 +673,7 @@ The first option will continue to line `As I was saying...`. The second option w
 
 ## Variations
 
-In some cases you may have a dialogue that can be repeated multiple times. To make things more interesting, you can use variations `(` `)` to show a different message every time the dialogue is run.
+In some cases, you may have a dialogue that can be repeated multiple times. To make things more interesting, you can use variations `(` `)` to show a different message every time the dialogue is executed.
 
 ```
 -- simple lines
@@ -702,11 +698,11 @@ What are you doing here?
 
 There are a few different behaviours available for variations (`sequence`, `once`, `cycle`, `shuffle`):
 
-**cycle**(default): This option returns each item and, when reaching the end, starts again from the begining.
+**cycle**(default): This option returns each item and, when reaching the end, starts again from the beginning.
 
 **sequence**: It will return each item once, and then it will stick to the last one.
 
-For example, in the following block, the first time will return `Once`, second time `Twice` and every other call after that will return `I lost count...`.
+For example, in the following block, the first time will return `Once`, the second time `Twice` and every other call after that will return `I lost count...`.
 
 ```
 ( sequence
@@ -796,12 +792,12 @@ some text here { set is_happy = true}
 some text here { set is_happy = true, is_naughty = false, a = b, b = 2 }
 ```
 
-Regardless the position, the assignment will always be executed when the line is returned.
+Regardless of the position, the assignment will always be executed when the line is returned.
 
 
 ### Conditions
 
-Conditions are used to control which lines should be shown. They do not require any special keyword, but you can optionally use `when` to explicitally show that the block is a condition. Examples:
+Conditions are used to control which lines should be shown. They do not require any special keyword, but you can optionally use `when` to explicitly show that the block is a condition. Examples:
 
 ```
 { set something = true }
@@ -933,5 +929,5 @@ In the example above, due to the conditional options, `OPTIONS_COUNT` is 2. If m
 
 That's pretty much all features implemented. You can check the `/examples` folder for more examples.
 
-All examples in this page are valid dialogues that can be run on the live [interpreter](https://viniciusgerevini.github.io/clyde/).
+All examples on this page are valid dialogues that can be run on the live [interpreter](https://viniciusgerevini.github.io/clyde/).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Clyde is a language for writing game dialogues. It supports branching dialogues, translations and interfacing with your game through variables and events.
 
-It was heavily inspired by [Ink](https://github.com/inkle/ink), but it focus on dialogues instead of narratives.
+It was heavily inspired by [Ink](https://github.com/inkle/ink), but it focuses on dialogues instead of narratives.
 
 You can play with the online editor [here](https://viniciusgerevini.github.io/clyde/).
 
@@ -35,7 +35,7 @@ This dialogue results in something like this:
 ![Clyde interpreted dialogue sample](clyde_readme_sample.png "Clyde dialogue sample")
 
 
-This is just a simple example. There are many features not included above like branching, variations, tags and ids.
+This is just a simple example. There are many features not included above, like branching, variations, tags and ids.
 
 You can read the complete language definition with examples on [LANGUAGE.md](./LANGUAGE.md).
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.0.0 (2021-11-21)
+
+### Breaking changes
+
+Options do not display first line by default. Square brackets are not allowed anymore.
+
+### Changed
+
+- Updated @clyde-lang/parser to v2.0.0 and @clyde-lang/interpreter to v2.0.0.
+- Option lines are not included as content anymore.
+- Supports `=` to keep old behaviour of showing the main line.
+- Brackets (`[]`) for display only options are not required or allowed.
+
 ## 1.0.1 (2021-10-21)
 
 ### Breaking changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clyde-lang/cli",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "CLI tool for executing, parsing and debugging Clyde dialogue files",
   "main": "./cjs/index.js",
   "author": "Vinicius Gerevini <viniciusgerevini@gmail.com>",
@@ -15,8 +15,8 @@
     "clyde": "./src/cli.js"
   },
   "dependencies": {
-    "@clyde-lang/interpreter": "^1.0.0",
-    "@clyde-lang/parser": "^1.0.0",
+    "@clyde-lang/interpreter": "^2.0.0",
+    "@clyde-lang/parser": "^2.0.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -307,15 +307,15 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@clyde-lang/interpreter@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@clyde-lang/interpreter/-/interpreter-1.0.0.tgz#ab83b430bcb168366349992047815da833599065"
-  integrity sha512-8OY3oK6Ilb1gRmDrsvu5UPuaAVlFMa6o8nXzbIrUtxuMx3BE2J//mu+Wb4tnhVeu6qOqVu68vPJoeTTnH0HHTg==
+"@clyde-lang/interpreter@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@clyde-lang/interpreter/-/interpreter-2.0.0.tgz#af3a548f05bcdc32813f16763820b363d24821e1"
+  integrity sha512-MIaPvL44I7zVfIP8Xlmt1LAm9tI7+qA9EpYU/mq2GTXUMXqqSytVCld6BQJ4Kp+G2wPNmHRg3Sqr5GFnTTuoog==
 
-"@clyde-lang/parser@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@clyde-lang/parser/-/parser-1.0.0.tgz#176c625673ccd6921fa1c05d203ac4887d3967ef"
-  integrity sha512-Qt6ni/eAW7kNcaVAIrtdj2eGl2hDbN2bdfIBsux2uU6LNqijDAKN+Lyp1FhM3p3VHZhBhbFiDntrRXiNrgL4Pw==
+"@clyde-lang/parser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@clyde-lang/parser/-/parser-2.0.0.tgz#9b9650e4cc6b0895ad0e989be919236ae3d28d88"
+  integrity sha512-GPcmUbCtfFqqirYsqVcCUurqSolZWhEv9wrmi4bZzn4muFISdBhLyHFZhwRty0FdIg7GqOuP81aSyJD4+yW8YA==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,11 +1,11 @@
 {
   "name": "clyde-editor",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "homepage": "https://viniciusgerevini.github.io/clyde",
   "dependencies": {
-    "@clyde-lang/interpreter": "^1.0.0",
-    "@clyde-lang/parser": "^1.0.0",
+    "@clyde-lang/interpreter": "^2.0.0",
+    "@clyde-lang/parser": "^2.0.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.14",

--- a/editor/src/App.js
+++ b/editor/src/App.js
@@ -21,15 +21,15 @@ const load = () => {
 Narrator: Hello there!
 Player: Hi!
 Narrator: What do you want to talk about?
-  + [Life]
+  + Life
     -> about life <-
-  + [The universe]
+  + The universe
     -> about the universe <-
-  * [Everything else... #some_tag]
+  * Everything else... #some_tag
     -> about everything else <-
-  + [Earth]
+  + Earth
     -> about earth <-
-  + [Nothing]
+  + Nothing
     -> goodbye <-
 
 

--- a/editor/src/App.js
+++ b/editor/src/App.js
@@ -8,12 +8,9 @@ import MainPanelsContainer from './screens/MainPanelsContainer';
 
 import { loadState, saveState } from './storage/local-storage';
 
-const load = () => {
-  const data = loadState() || { editor: {} };
 
 
-  if (!data.editor?.currentValue) {
-    data.editor.currentValue = `--
+const EDITOR_DEFAULT_VALUE = `--
 --
 -- This is a sample dialogue.
 --
@@ -78,6 +75,13 @@ Player: What do you know about earth?
 Player: Bye!
 Narrator: Good bye!
 `;
+
+
+const load = () => {
+  const data = loadState() || { editor: reducer.editor?.createEmptyState() };
+
+  if (data.editor && !data.editor.currentValue) {
+    data.editor.currentValue = EDITOR_DEFAULT_VALUE;
   }
 
   return {

--- a/editor/src/interpreter/Interpreter.js
+++ b/editor/src/interpreter/Interpreter.js
@@ -25,7 +25,7 @@ export default function Interpreter(p) {
     timeline,
     shouldShowExtraMetadata,
     shouldShowDebugPane,
-    debugPaneDirection,
+    debugPaneDirection = "horizontal",
     singleBubblePresentation,
     clydeDocument,
     setBlock,

--- a/editor/src/interpreter/Interpreter.test.js
+++ b/editor/src/interpreter/Interpreter.test.js
@@ -77,9 +77,9 @@ describe('Interpreter component', () => {
 
     const content = `
 what do you think?
-  * [yes]
+  * yes
     nice!
-  * [no]
+  * no
     ok!
 `;
 
@@ -118,9 +118,9 @@ what do you think?
 
     const content = `
 speaker: what do you think?
-  * [yes]
+  * yes
     nice!
-  * [no]
+  * no
     ok!
 `;
 
@@ -168,9 +168,9 @@ speaker: what do you think?
 
     const content = `
 what do you think?
-  * [yes]
+  * yes
     nice!
-  * [no]
+  * no
     ok!
 <<
 `;
@@ -524,7 +524,7 @@ hi
 first line
 second line
 third line
-* [yes]
+* yes
   nice!
 `;
 
@@ -580,17 +580,17 @@ third line
       const content = `
 first line
 hello
-  * [hi]
+  * hi
     hi!
 
 second line
 hello
-  * [hi]
+  * hi
     hi!
 
 third line
 hello
-  * [hi]
+  * hi
     hi!
 this is the end
 `;

--- a/editor/src/interpreter/Interpreter.test.js
+++ b/editor/src/interpreter/Interpreter.test.js
@@ -225,7 +225,7 @@ what do you think?
     const id = queryAllByLabelText(/line id/i);
     const tags = queryAllByLabelText(/line tags/i);
 
-    expect(queryAllByLabelText(/metadata/i).length).toBe(3);
+    expect(queryAllByLabelText(/metadata/i).length).toBe(4); // this is 4 because it includes the menu
     expect(id[0].innerHTML).toMatch(/.*id:.*some_id/);
     expect(tags[0].innerHTML).toMatch(/.*tags:.*tag/);
 
@@ -340,7 +340,6 @@ neither this one
           timeline={[]}/>
       );
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByText(/Show debug pane/i));
 
       expect(showDebugPaneStub).toHaveBeenCalled();
@@ -360,7 +359,6 @@ neither this one
           timeline={[]}/>
       );
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByText(/Hide debug pane/i));
 
       expect(hideDebugPaneStub).toHaveBeenCalled();
@@ -379,7 +377,6 @@ neither this one
           timeline={[]}/>
       );
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByText(/Show metadata/i));
 
       expect(showExtraMetadataStub).toHaveBeenCalled();
@@ -397,7 +394,6 @@ neither this one
           shouldShowExtraMetadata
           timeline={[]}/>
       );
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByText(/Hide metadata/i));
 
       expect(hideExtraMetadataStub).toHaveBeenCalled();
@@ -416,7 +412,6 @@ neither this one
           timeline={[]}/>
       );
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByLabelText(/Set single bubble dialogue/i));
 
       expect(enableSingleBubbleDialogueStub).toHaveBeenCalled();
@@ -435,7 +430,6 @@ neither this one
           timeline={[]}/>
       );
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByLabelText(/Set multi bubble dialogue/i));
 
       expect(disableSingleBubbleDialogueStub).toHaveBeenCalled();

--- a/editor/src/interpreter/InterpreterToolbar.js
+++ b/editor/src/interpreter/InterpreterToolbar.js
@@ -1,9 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from 'styled-components';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-  faCog,
   faRedoAlt,
   faFastForward,
   faBug,
@@ -13,8 +12,6 @@ import {
   faGhost,
   faHandSparkles,
 } from '@fortawesome/free-solid-svg-icons'
-
-import DropDownMenu, { DropDownItem } from '../screens/DropdownMenu';
 
 const InterpreterToolbarWrapper = styled.div`
   display: flex;
@@ -34,17 +31,6 @@ const InterpreterToolbarWrapper = styled.div`
   }
 `;
 
-const IconWrapper = styled.span`
-  cursor: pointer;
-  position: relative;
-  margin: 0px 20px;
-  > svg {
-    font-size: 1.5em;
-    &:hover {
-      color: #222;
-    }
-  }
-`;
 
 export default function InterpreterToolbar(properties) {
   const {
@@ -67,16 +53,10 @@ export default function InterpreterToolbar(properties) {
     clearEvents,
   } = properties;
 
-  const [isMenuVisible, setMenuVisibility] = useState(false);
-
   const selectBlock = (blockName) => {
     setBlock(blockName);
     clearTimeline();
     dialogue.start(blockName);
-  };
-
-  const toggleMenu = () => {
-    setMenuVisibility(!isMenuVisible);
   };
 
   const toggleMultipleBubbles = () => {
@@ -158,28 +138,9 @@ export default function InterpreterToolbar(properties) {
         onClick={toggleMultipleBubbles}
       />
 
-      <IconWrapper>
-        <FontAwesomeIcon icon={faCog} onClick={toggleMenu} title="Interpreter options"/>
-        { isMenuVisible ? (
-          <DropDownMenu onClick={toggleMenu} style={{ width: '280px' }}>
+      <FontAwesomeIcon icon={faReceipt} onClick={toggleExtraMetadata} title={`${shouldShowExtraMetadata ? 'Hide' : 'Show'} metadata`}/>
 
-            <DropDownItem
-              label="Toggle extra metadata"
-              onClick={toggleExtraMetadata}
-              icon={faReceipt}
-              text={`${shouldShowExtraMetadata ? 'Hide' : 'Show'} metadata`}
-            />
-
-            <DropDownItem
-              label="Toggle debug pane"
-              onClick={toggleDebugPane}
-              icon={faBug}
-              text={`${shouldShowDebugPane ? 'Hide' : 'Show'} debug pane`}
-              />
-           </DropDownMenu>
-          ) : ''
-        }
-      </IconWrapper>
+      <FontAwesomeIcon icon={faBug} onClick={toggleDebugPane} title={`${shouldShowDebugPane ? 'Hide' : 'Show'} debug pane`}/>
     </InterpreterToolbarWrapper>
   );
 }

--- a/editor/src/screens/MainPanels.js
+++ b/editor/src/screens/MainPanels.js
@@ -47,7 +47,7 @@ export default function MainPanels(props) {
     isInterpreterEnabled = true,
     toggleEditor,
     toggleInterpreter,
-    interpreterSplitDirection = 'vertical',
+    interpreterSplitDirection = 'horizontal',
     changeInterpreterSplitDirection,
     // editor
     editorDefaultValue,

--- a/editor/src/screens/MainPanels.test.js
+++ b/editor/src/screens/MainPanels.test.js
@@ -43,13 +43,6 @@ describe('MainPanels component', () => {
     expect(stubToggleInterpreter).toHaveBeenCalledWith(true);
   });
 
-  it('defaults split direction to vertical', () => {
-    const { container } = render(<MainPanels/>);
-    const panel = container.querySelector('div[direction="vertical"]');
-
-    expect(panel).toBeInTheDocument();
-  });
-
   it('configures split direction as horizontal', () => {
     const { container } = render(<MainPanels interpreterSplitDirection="horizontal" />);
     const panel = container.querySelector('div[direction="horizontal"]');
@@ -59,7 +52,7 @@ describe('MainPanels component', () => {
 
   it('sets split direction as horizontal', () => {
     const stubDirectionChange = jest.fn();
-    const { getByLabelText } = render(<MainPanels changeInterpreterSplitDirection={stubDirectionChange} />);
+    const { getByLabelText } = render(<MainPanels interpreterSplitDirection="vertical" changeInterpreterSplitDirection={stubDirectionChange} />);
 
     fireEvent.click(getByLabelText(/Toggle settings menu/i));
     fireEvent.click(getByLabelText(/Change split direction/i));

--- a/editor/src/screens/MainPanelsContainer.test.js
+++ b/editor/src/screens/MainPanelsContainer.test.js
@@ -193,7 +193,6 @@ describe('MainPanelsContainer', () => {
       );
       const { getByLabelText, getByText } = render(<Provider store={store}><MainPanelsContainer /></Provider>);
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByText(/Show debug pane/i));
 
       const action = store.getActions()[0];
@@ -209,7 +208,6 @@ describe('MainPanelsContainer', () => {
       );
       const { getByLabelText, getByText } = render(<Provider store={store}><MainPanelsContainer /></Provider>);
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByText(/Hide debug pane/i));
 
       const action = store.getActions()[0];
@@ -255,7 +253,6 @@ describe('MainPanelsContainer', () => {
       );
       const { getByLabelText, getByText } = render(<Provider store={store}><MainPanelsContainer /></Provider>);
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByText(/Show metadata/i));
 
       const action = store.getActions()[0];
@@ -271,7 +268,6 @@ describe('MainPanelsContainer', () => {
       );
       const { getByLabelText, getByText } = render(<Provider store={store}><MainPanelsContainer /></Provider>);
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByText(/Hide metadata/i));
 
       const action = store.getActions()[0];
@@ -288,7 +284,6 @@ describe('MainPanelsContainer', () => {
       );
       const { getByLabelText } = render(<Provider store={store}><MainPanelsContainer /></Provider>);
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByLabelText(/Set single bubble dialogue/i));
 
       const action = store.getActions()[0];
@@ -304,7 +299,6 @@ describe('MainPanelsContainer', () => {
       );
       const { getByLabelText } = render(<Provider store={store}><MainPanelsContainer /></Provider>);
 
-      fireEvent.click(getByLabelText(/Interpreter options/i));
       fireEvent.click(getByLabelText(/Set multi bubble dialogue/i));
 
       const action = store.getActions()[0];

--- a/editor/yarn.lock
+++ b/editor/yarn.lock
@@ -1210,15 +1210,15 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@clyde-lang/interpreter@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@clyde-lang/interpreter/-/interpreter-1.0.0.tgz#ab83b430bcb168366349992047815da833599065"
-  integrity sha512-8OY3oK6Ilb1gRmDrsvu5UPuaAVlFMa6o8nXzbIrUtxuMx3BE2J//mu+Wb4tnhVeu6qOqVu68vPJoeTTnH0HHTg==
+"@clyde-lang/interpreter@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@clyde-lang/interpreter/-/interpreter-2.0.0.tgz#af3a548f05bcdc32813f16763820b363d24821e1"
+  integrity sha512-MIaPvL44I7zVfIP8Xlmt1LAm9tI7+qA9EpYU/mq2GTXUMXqqSytVCld6BQJ4Kp+G2wPNmHRg3Sqr5GFnTTuoog==
 
-"@clyde-lang/parser@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@clyde-lang/parser/-/parser-1.0.0.tgz#176c625673ccd6921fa1c05d203ac4887d3967ef"
-  integrity sha512-Qt6ni/eAW7kNcaVAIrtdj2eGl2hDbN2bdfIBsux2uU6LNqijDAKN+Lyp1FhM3p3VHZhBhbFiDntrRXiNrgL4Pw==
+"@clyde-lang/parser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@clyde-lang/parser/-/parser-2.0.0.tgz#9b9650e4cc6b0895ad0e989be919236ae3d28d88"
+  integrity sha512-GPcmUbCtfFqqirYsqVcCUurqSolZWhEv9wrmi4bZzn4muFISdBhLyHFZhwRty0FdIg7GqOuP81aSyJD4+yW8YA==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"

--- a/examples/dialogue_with_branching.clyde
+++ b/examples/dialogue_with_branching.clyde
@@ -5,15 +5,15 @@
 Narrator: Hello there!
 Player: Hi!
 Narrator: What do you want to talk about?
-  + [Life]
+  + Life
     -> about life <-
-  + [The universe]
+  + The universe
     -> about the universe <-
-  * [Everything else... #some_tag]
+  * Everything else... #some_tag
     -> about everything else <-
-  + [Earth]
+  + Earth
     -> about earth <-
-  + [Nothing]
+  + Nothing
     -> goodbye <-
 
 

--- a/examples/pulp.clyde
+++ b/examples/pulp.clyde
@@ -3,7 +3,7 @@
 
 { not introductionMade } Jules: Okay now, tell me about that. { set introductionMade =  true, europeTopicsTalked = 0 }
 Vincent: What do you want to know?
-  * Jules: Is hash legal there?
+  *= Jules: Is hash legal there?
     Vincent: Yes, but is ain't a hundred percent legal.
              I mean you can't walk into a restaurant, roll a joint,
              and start puffin' away. You're only supposed to smoke in
@@ -17,7 +17,7 @@ Vincent: What do you want to know?
              Searching you is a right that the cops in Amsterdam don't have.
     Jules: That did it, man - I'm f**n' goin', that's all there is to it.
     <-
-  + { europeTopicsTalked < 4 }  [Something about Europe.]
+  + { europeTopicsTalked < 4 }  Something about Europe.
     { europeTopicsTalked == 0 }
              Vincent: You know what the funniest thing about Europe is?
              Jules: what?
@@ -29,14 +29,14 @@ Vincent: What do you want to know?
     )
 
     About Europe...
-      * [You can buy beer in movie theatres.]
+      * You can buy beer in movie theatres.
         Vincent: Well, in Amsterdam, you can buy beer in a
                  movie theatre.
         Vincent: And I don't mean in a paper
                  cup either. They give you a glass of beer,
         { set europeTopicsTalked += 1}
         <-
-      * Vincent: You know what they call a Quarter Pounder with Cheese in Paris?
+      *= Vincent: You know what they call a Quarter Pounder with Cheese in Paris?
         Jules: They don't call it a Quarter Pounder with Cheese?
         Vincent: No, they got the metric system there, they wouldn't know what
                  the f a Quarter Pounder is.
@@ -47,11 +47,11 @@ Vincent: What do you want to know?
         { set quarterPounderTalkCompleted = true }
         { set europeTopicsTalked += 1}
         <-
-      * { quarterPounderTalkCompleted } Jules: What do they call a Whopper?
+      *= { quarterPounderTalkCompleted } Jules: What do they call a Whopper?
                                         Vincent: I dunno, I didn't go into a Burger King.
                                         { set europeTopicsTalked += 1}
                                         <-
-      * [What they put on the french fries instead of ketchup.]
+      * What they put on the french fries instead of ketchup.
         Vincent: You know what they put on french fries in Holland
                  instead of ketchup?
         Jules: What?
@@ -62,11 +62,11 @@ Vincent: What do you want to know?
         Jules: Uuccch!
         { set europeTopicsTalked += 1}
         <-
-      + { OPTIONS_COUNT > 1 } [I'm suddenly not interested anymore.]
+      + { OPTIONS_COUNT > 1 } I'm suddenly not interested anymore.
         Jules: We talk about this another time.
     { set europeTalkCompleted = true }
     <-
-  + { OPTIONS_COUNT > 1 } [Nah, maybe another time]
+  + { OPTIONS_COUNT > 1 } Nah, maybe another time
     ( shuffle
        - Vincent: Alright!
        - Vincent: No problem!

--- a/examples/pulp_with_blocks.clyde
+++ b/examples/pulp_with_blocks.clyde
@@ -6,11 +6,11 @@
 
 { not introductionMade } Jules: Okay now, tell me about that. { set introductionMade =  true, europeTopicsTalked = 0 }
 Vincent: What do you want to know?
-  * [Is hash legal there?]
+  * Is hash legal there?
     -> about hash <-
-  + [Something about Europe.] { when europeTopicsTalked < 4 }
+  + Something about Europe. { when europeTopicsTalked < 4 }
     -> about europe <-
-  + [Nah, maybe another time] { when OPTIONS_COUNT > 1 }
+  + Nah, maybe another time { when OPTIONS_COUNT > 1 }
     ( shuffle
        - Vincent: Alright!
        - Vincent: No problem!
@@ -49,15 +49,15 @@ Jules: That did it, man - I'm f**n' goin', that's all there is to it.
   - Jules: Tell me more about Europe.
 )
 About Europe...
-  * [You can buy beer in movie theatres.]
+  * You can buy beer in movie theatres.
     -> beer in theathres <-
-  * [What they call a Quarter Pounder in Paris]
+  * What they call a Quarter Pounder in Paris
     -> quarter pounder talk <-
-  * [What they call a Whopper] { when quarterPounderTalkCompleted }
+  * What they call a Whopper { when quarterPounderTalkCompleted }
     -> whopper talk <-
-  * [What they put on the french fries instead of ketchup.]
+  * What they put on the french fries instead of ketchup.
     -> french fries talk <-
-  + { OPTIONS_COUNT > 1 } [I'm suddenly not interested anymore.]
+  + { OPTIONS_COUNT > 1 } I'm suddenly not interested anymore.
     Jules: We talk about this another time.
 { set europeTalkCompleted = true }
 <-

--- a/interpreter/CHANGELOG.md
+++ b/interpreter/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.0.0 (2021-11-21)
+
+### Breaking Changes
+
+Updated @clyde-lang/parser to v2.0.0 to support new Options behaviour.
+
+- Option lines are not included as content anymore.
+- Supports `=` to keep old behaviour of showing the main line.
+- Brackets (`[]`) for display only options are not required or allowed.
+
 ## 1.0.0 (2021-10-21)
 
 ### Breaking changes

--- a/interpreter/package.json
+++ b/interpreter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clyde-lang/interpreter",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Interpreter for Clyde dialogue language",
   "main": "./cjs/index.js",
   "types": "./types/index.d.ts",

--- a/interpreter/package.json
+++ b/interpreter/package.json
@@ -13,7 +13,7 @@
     "test": "node --experimental-vm-modules node_modules/.bin/jest --coverage"
   },
   "devDependencies": {
-    "@clyde-lang/parser": "^1.0.0",
+    "@clyde-lang/parser": "^2.0.0",
     "ascjs": "^4.0.3",
     "jest": "^27.2.4"
   },

--- a/interpreter/src/interpreter-blocks-diverts.spec.js
+++ b/interpreter/src/interpreter-blocks-diverts.spec.js
@@ -83,10 +83,10 @@ this is another block
       const content = parse(`
 Hello!
 question
-  * [yes]
+  * yes
     -> yes_answer
     continue
-  * [no]
+  * no
     -> no_answer
 end
 
@@ -114,11 +114,11 @@ no a!
       const content = parse(`
 Hello!
 question
-  * [yes]
+  * yes
     -> yes_answer
     continue
     <-
-  * [no]
+  * no
     -> no_answer
 end
 

--- a/interpreter/src/interpreter-conditions.spec.js
+++ b/interpreter/src/interpreter-conditions.spec.js
@@ -42,13 +42,13 @@ I believe this is all
   it('use condition on options', () => {
     const content = parse(`
 {set choice_count = 0 }
-+ [always]
++ always
   forevaaa
   <-
-* { choice_count < 1 } [one time]
+* { choice_count < 1 } one time
   a { set choice_count += 1 }
   <-
-+ { choice_count < 2 } [twice]
++ { choice_count < 2 } twice
   b { set choice_count += 1 }
   <-
 `

--- a/interpreter/src/interpreter-options.spec.js
+++ b/interpreter/src/interpreter-options.spec.js
@@ -4,7 +4,7 @@ import { Interpreter } from './interpreter';
 describe("Interpreter: options", () => {
 
   it('continue flow after selecting an option', () => {
-    const content = parse('\nHey hey\nspeaker: hello\n  * [a]\n   aa\n   ab\n  * [b]\n   ba\n   bb\nend\n');
+    const content = parse('\nHey hey\nspeaker: hello\n  * a\n   aa\n   ab\n  * b\n   ba\n   bb\nend\n');
     const dialogue = Interpreter(content);
 
     expect(dialogue.getContent()).toEqual({ type: 'line', text: 'Hey hey' });
@@ -16,7 +16,7 @@ describe("Interpreter: options", () => {
   });
 
   it('handle sticky and normal options', () => {
-    const content = parse('speaker: hello #name_tag\n  * [a]\n   aa\n   ab\n  * [b $abc #option_tag]\n   ba\n   bb\n  + [c]\n   ca\n   cb\n');
+    const content = parse('speaker: hello #name_tag\n  * a\n   aa\n   ab\n  * b $abc #option_tag\n   ba\n   bb\n  + c\n   ca\n   cb\n');
     const dialogue = Interpreter(content);
 
     expect(dialogue.getContent()).toEqual({ type: 'options', name: 'hello', speaker: 'speaker', tags: [ 'name_tag' ], options: [{ label: 'a' },{ label: 'b', id: 'abc', tags: [ 'option_tag' ] }, { label: 'c' } ] });
@@ -43,7 +43,7 @@ describe("Interpreter: options", () => {
   });
 
   it('use fallback option when others not available', () => {
-    const content = parse('\nHey hey\nspeaker: hello\n  * a\n  > b\nend\n');
+    const content = parse('\nHey hey\nspeaker: hello\n  *= a\n  >= b\nend\n');
     const dialogue = Interpreter(content);
 
     expect(dialogue.getContent()).toEqual({ type: 'line', text: 'Hey hey' });
@@ -58,7 +58,7 @@ describe("Interpreter: options", () => {
   });
 
   it('expose special variable OPTIONS_COUNT', () => {
-    const content = parse('speaker: hello\n  * [a]\n   a %OPTIONS_COUNT%\n  * [b]\n   b %OPTIONS_COUNT%\n  * [c %OPTIONS_COUNT% left]\n   c %OPTIONS_COUNT%\n');
+    const content = parse('speaker: hello\n  * a\n   a %OPTIONS_COUNT%\n  * b\n   b %OPTIONS_COUNT%\n  * c %OPTIONS_COUNT% left\n   c %OPTIONS_COUNT%\n');
     const dialogue = Interpreter(content);
 
     expect(dialogue.getContent()).toEqual({ type: 'options', name: 'hello', speaker: 'speaker', options: [{ label: 'a' },{ label: 'b' }, { label: 'c 3 left' } ] });
@@ -87,13 +87,13 @@ describe("Interpreter: options", () => {
   it('use special variable OPTIONS_COUNT as condition', () => {
     const content = parse(`
 hello %OPTIONS_COUNT%
-    * [Yes]
+    * Yes
       yep
       <-
-    * [No]
+    * No
       nope
       <-
-    + { OPTIONS_COUNT > 1 } [What?]
+    + { OPTIONS_COUNT > 1 } What?
       wat
       <-
 `);
@@ -121,7 +121,7 @@ hello %OPTIONS_COUNT%
   });
 
   it('fails when selecting wrong index', () => {
-    const content = parse('hello $123\n * [a]\n  aa\n * [b]\n  ba\n');
+    const content = parse('hello $123\n * a\n  aa\n * b\n  ba\n');
     const dialogue = Interpreter(content);
     expect(dialogue.getContent()).toEqual({ id: '123', type: 'options', name: 'hello', options: [{ label: 'a' }, { label: 'b' } ] });
     expect(() => dialogue.choose(66)).toThrow(/Index 66 not available./);
@@ -132,7 +132,7 @@ hello %OPTIONS_COUNT%
     const content = parse(`
 { set europeTopicsTalked = 0 }
 Vincent: What do you want to know?
-  * [Is hash legal there?]
+  * Is hash legal there?
     Jules: is hash legal there?
     Vincent: yes, but is ain't a hundred percent legal.
              I mean you can't walk into a restaurant, roll a joint,
@@ -147,19 +147,19 @@ Vincent: What do you want to know?
              Searching you is a right that the cops in Amsterdam don't have."
     Jules: That did it, man - I'm f**n' goin', that's all there is to it.
     <-
-  + { europeTopicsTalked < 4 } [Something about Europe.]
+  + { europeTopicsTalked < 4 } Something about Europe.
     Vincent: You know what the funniest thing about Europe is?
     Jules: what?
     Vincent: It's the little differences. A lotta the same sh*t we got here, they
              they got there, but there they're a little different.
     Jules: Examples?
-      * [You can buy a beer in a movie theatre.]
+      * You can buy a beer in a movie theatre.
         Vincent: Well, in Amsterdam, you can buy beer in a
                  movie theatre. And I don't mean in a paper
                  cup either. They give you a glass of beer,
         { set europeTopicsTalked += 1}
         <-
-      * [You know what they call a Quarter Pounder with Cheese in Paris?]
+      * You know what they call a Quarter Pounder with Cheese in Paris?
         Vincent: You know what they call a Quarter Pounder with Cheese in Paris?
         Jules: They don't call it a Quarter Pounder with Cheese?
         Vincent: No, they got the metric system there, they wouldn't know what
@@ -171,11 +171,11 @@ Vincent: What do you want to know?
         { set quarterPounderTalkCompleted = true }
         { set europeTopicsTalked += 1}
         <-
-      * { quarterPounderTalkCompleted } [What do they call a Whopper?]
+      * { quarterPounderTalkCompleted } What do they call a Whopper?
         Jules: What do they call a Whopper?
         Vincent: I dunno, I didn't go into a Burger King.
         { set europeTopicsTalked += 1}
-      * [What they put on the french fries instead of ketchup.]
+      * What they put on the french fries instead of ketchup.
         Vincent: You know what they put on french fries in Holland
                  instead of ketchup?
         Jules: What?
@@ -186,11 +186,11 @@ Vincent: What do you want to know?
         Jules: Uuccch!
         { set europeTopicsTalked += 1}
         <-
-      + { OPTIONS_COUNT > 1 } [I'm suddenly not interested anymore.]
+      + { OPTIONS_COUNT > 1 } I'm suddenly not interested anymore.
         Jules: We talk about this another time.
     { set europeTalkCompleted = true }
     <-
-  + { OPTIONS_COUNT > 1 } [Nah, maybe another time]
+  + { OPTIONS_COUNT > 1 } Nah, maybe another time
         (
           - Vincent: Alright!
           - Vincent: No problem!
@@ -227,8 +227,8 @@ Jules: Let's get to work!
     const content = parse(`
 Hey hey
 speaker: hello
-      * a { set something = true }
-      * b { when not something }
+      *= a { set something = true }
+      *= b { when not something }
 hey
 `);
     const dialogue = Interpreter(content);
@@ -246,9 +246,9 @@ hey
     const content = parse(`
 Hey hey
 speaker: hello
-      * a { set something = true }
+      *= a { set something = true }
         hey you
-      * b
+      *= b
 hey
 `);
     const dialogue = Interpreter(content);
@@ -265,9 +265,9 @@ hey
     const content = parse(`
 Hey hey
 speaker: hello
-      * { not something } a { set something = true }
-      * b { when not something }
-      * { set something = 2 } c  { when a == 42 }
+      *= { not something } a { set something = true }
+      *= b { when not something }
+      *= { set something = 2 } c  { when a == 42 }
 hey
 `);
     const dialogue = Interpreter(content);

--- a/interpreter/src/interpreter.spec.js
+++ b/interpreter/src/interpreter.spec.js
@@ -79,9 +79,9 @@ describe("Interpreter", () => {
   describe('persistence', () => {
     it('get all data and start new instance with right state', () =>{
       const content = parse(`
-* [a]
+* a
   Hi!{ set someVar = 1 }
-* [b]
+* b
   hello %someVar%
 `);
       const dialogue = Interpreter(content);
@@ -99,9 +99,9 @@ describe("Interpreter", () => {
 
     it('get all data and load in another instance', () =>{
       const content = parse(`
-* [a]
+* a
   set as 1!{ set someVar = 1 }
-* [b]
+* b
   set as 2!{ set someVar = 2 }
 result is %someVar%
 `);
@@ -123,9 +123,9 @@ result is %someVar%
 
     it('make sure options are right when loading previously stringified data', () =>{
       const content = parse(`
-* [a]
+* a
   set as 1!{ set someVar = 1 }
-* [b]
+* b
   set as 2!{ set someVar = 2 }
 result is %someVar%
 `);
@@ -178,7 +178,7 @@ This will not be replaced
 This should be replaced $abc
 This will not be replaced either $def
 replace $ghi
-  * [replace $jkl]
+  * replace $jkl
     <-
 (
   -replace $mno

--- a/interpreter/yarn.lock
+++ b/interpreter/yarn.lock
@@ -307,10 +307,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@clyde-lang/parser@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@clyde-lang/parser/-/parser-1.0.0.tgz#176c625673ccd6921fa1c05d203ac4887d3967ef"
-  integrity sha512-Qt6ni/eAW7kNcaVAIrtdj2eGl2hDbN2bdfIBsux2uU6LNqijDAKN+Lyp1FhM3p3VHZhBhbFiDntrRXiNrgL4Pw==
+"@clyde-lang/parser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@clyde-lang/parser/-/parser-2.0.0.tgz#9b9650e4cc6b0895ad0e989be919236ae3d28d88"
+  integrity sha512-GPcmUbCtfFqqirYsqVcCUurqSolZWhEv9wrmi4bZzn4muFISdBhLyHFZhwRty0FdIg7GqOuP81aSyJD4+yW8YA==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.0.0 (2021-11-21)
+
+### Breaking Changes
+
+Supporting new language options behaviour.
+
+- Option lines are not included as content anymore.
+- Supports `=` to keep old behaviour of showing the main line.
+- Brackets (`[]`) for display only options are not required or allowed.
+
 ## 1.0.0 (2021-10-21)
 
 ### Breaking Changes

--- a/parser/package.json
+++ b/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clyde-lang/parser",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Parser for Clyde dialogue language",
   "main": "./cjs/index.js",
   "types": "./types/index.d.ts",

--- a/parser/src/lexer.js
+++ b/parser/src/lexer.js
@@ -5,8 +5,6 @@ export const TOKENS = {
   OPTION: 'OPTION',
   STICKY_OPTION: 'STICKY_OPTION',
   FALLBACK_OPTION: 'FALLBACK_OPTION',
-  SQR_BRACKET_OPEN: 'SQR_BRACKET_OPEN',
-  SQR_BRACKET_CLOSE: 'SQR_BRACKET_CLOSE',
   BRACKET_OPEN: 'BRACKET_OPEN',
   BRACKET_CLOSE: 'BRACKET_CLOSE',
   EOF: 'EOF',
@@ -68,8 +66,6 @@ const tokenFriendlyHint = {
   [TOKENS.OPTION]: '*',
   [TOKENS.STICKY_OPTION]: '+',
   [TOKENS.FALLBACK_OPTION]: '>',
-  [TOKENS.SQR_BRACKET_OPEN]: '[',
-  [TOKENS.SQR_BRACKET_CLOSE]: ']',
   [TOKENS.BRACKET_OPEN]: '(',
   [TOKENS.BRACKET_CLOSE]: ')',
   [TOKENS.EOF]: 'EOF',
@@ -290,13 +286,11 @@ export function tokenize(input) {
     return Token(token, line, initialColumn);
   };
 
-  // handle brackets
-  const handleBrackets = () => {
-    const token = input[position] === '[' ? TOKENS.SQR_BRACKET_OPEN : TOKENS.SQR_BRACKET_CLOSE;
+  const handleOptionDisplayChar = () => {
     const initialColumn = column;
     column += 1;
     position += 1;
-    return Token(token, line, initialColumn);
+    return Token(TOKENS.ASSIGN, line, initialColumn);
   };
 
   const handleLineId = () => {
@@ -751,8 +745,8 @@ export function tokenize(input) {
       return handleOption();
     }
 
-    if (isCurrentMode(MODES.OPTION) && ['[', ']' ].includes(input[position])) {
-      return handleBrackets();
+    if (isCurrentMode(MODES.OPTION) && input[position] === '=') {
+      return handleOptionDisplayChar();
     }
 
     if (input[position] === '$') {

--- a/parser/src/lexer.spec.js
+++ b/parser/src/lexer.spec.js
@@ -222,7 +222,7 @@ this is something
     hello again
 * a whole new list
   hello
-* [ hello ]
+*= hello
   hi
   this is just some text with [ brackets ]
   and this is some text with * and + and >
@@ -248,9 +248,8 @@ this is something
       { token: TOKENS.TEXT, value: 'hello', line: 7, column: 2 },
       { token: TOKENS.DEDENT, line: 8, column: 0 },
       { token: TOKENS.OPTION, line: 8, column: 0 },
-      { token: TOKENS.SQR_BRACKET_OPEN, line: 8, column: 2 },
-      { token: TOKENS.TEXT, value: 'hello', line: 8, column: 4 },
-      { token: TOKENS.SQR_BRACKET_CLOSE, line: 8, column: 10 },
+      { token: TOKENS.ASSIGN, line: 8, column: 1 },
+      { token: TOKENS.TEXT, value: 'hello', line: 8, column: 3 },
       { token: TOKENS.INDENT, line: 9, column: 0 },
       { token: TOKENS.TEXT, value: 'hi', line: 9, column: 2 },
       { token: TOKENS.TEXT, value: 'this is just some text with [ brackets ]', line: 10, column: 2 },
@@ -268,7 +267,7 @@ speaker1: this is something
   * speaker2: this is another thing
     speaker3: hello
   + speaker4: this is a sticky option
-* [ speaker5: hello ]
+*= speaker5: hello
   speaker 1: this is ok
 `).getAll();
     expect(tokens).toEqual([
@@ -287,10 +286,9 @@ speaker1: this is something
       { token: TOKENS.TEXT, value: 'this is a sticky option', line: 4, column: 14 },
       { token: TOKENS.DEDENT, line: 5, column: 0 },
       { token: TOKENS.OPTION, line: 5, column: 0 },
-      { token: TOKENS.SQR_BRACKET_OPEN, line: 5, column: 2 },
-      { token: TOKENS.SPEAKER, value: 'speaker5', line: 5, column: 4 },
-      { token: TOKENS.TEXT, value: 'hello', line: 5, column: 14 },
-      { token: TOKENS.SQR_BRACKET_CLOSE, line: 5, column: 20 },
+      { token: TOKENS.ASSIGN, line: 5, column: 1 },
+      { token: TOKENS.SPEAKER, value: 'speaker5', line: 5, column: 3 },
+      { token: TOKENS.TEXT, value: 'hello', line: 5, column: 13 },
       { token: TOKENS.INDENT, line: 6, column: 0 },
       { token: TOKENS.SPEAKER, value: 'speaker 1', line: 6, column: 2 },
       { token: TOKENS.TEXT, value: 'this is ok', line: 6, column: 13 },
@@ -302,7 +300,7 @@ speaker1: this is something
     const tokens = tokenize(`
 speaker1: this is something $123
 * this is another thing $abc
-* [ hello $a1b2 ]
+*= hello $a1b2
 speaker1: this is something $123`).getAll();
     expect(tokens).toEqual([
       { token: TOKENS.SPEAKER, value: 'speaker1', line: 1, column: 0 },
@@ -312,10 +310,9 @@ speaker1: this is something $123`).getAll();
       { token: TOKENS.TEXT, value: 'this is another thing', line: 2, column: 2 },
       { token: TOKENS.LINE_ID, value: 'abc', line: 2, column: 24 },
       { token: TOKENS.OPTION, line: 3, column: 0 },
-      { token: TOKENS.SQR_BRACKET_OPEN, line: 3, column: 2 },
-      { token: TOKENS.TEXT, value: 'hello', line: 3, column: 4 },
-      { token: TOKENS.LINE_ID, value: 'a1b2', line: 3, column: 10 },
-      { token: TOKENS.SQR_BRACKET_CLOSE, line: 3, column: 16 },
+      { token: TOKENS.ASSIGN, line: 3, column: 1 },
+      { token: TOKENS.TEXT, value: 'hello', line: 3, column: 3 },
+      { token: TOKENS.LINE_ID, value: 'a1b2', line: 3, column: 9 },
       { token: TOKENS.SPEAKER, value: 'speaker1', line: 4, column: 0 },
       { token: TOKENS.TEXT, value: 'this is something', line: 4, column: 10 },
       { token: TOKENS.LINE_ID, value: '123', line: 4, column: 28 },

--- a/parser/src/parser-blocks-and-diverts.spec.js
+++ b/parser/src/parser-blocks-and-diverts.spec.js
@@ -83,10 +83,10 @@ line 4
 -> one
 -> END
 <-
-* [thats it]
+* thats it
   -> somewhere
   <-
-* [ does it work this way? ]
+* does it work this way?
   -> go
 `);
     const expected = {

--- a/parser/src/parser-logic.spec.js
+++ b/parser/src/parser-logic.spec.js
@@ -443,9 +443,9 @@ describe('parse: logic', () => {
 
     it('conditional option', () => {
       const result = parse(`
-* { some_var } option 1
-* option 2 { when some_var }
-* { some_other_var } option 3
+*= { some_var } option 1
+*= option 2 { when some_var }
+*= { some_other_var } option 3
 `);
       const expected = createDocPayload([{
         type: 'options',
@@ -824,9 +824,9 @@ describe('parse: logic', () => {
 
     it('options assignment', () => {
       const result = parse(`
-* { set a = 2 } option 1
-* option 2 { set b = 3 }
-* { set c = 4 } option 3
+*= { set a = 2 } option 1
+*= option 2 { set b = 3 }
+*= { set c = 4 } option 3
 `);
       const expected = createDocPayload([{
         type: 'options',
@@ -968,9 +968,9 @@ describe('parse: logic', () => {
 
     it('options trigger', () => {
       const result = parse(`
-* { trigger a } option 1
-* option 2 { trigger b }
-* { trigger c } option 3
+*= { trigger a } option 1
+*= option 2 { trigger b }
+*= { trigger c } option 3
 `);
       const expected = createDocPayload([{
         type: 'options',

--- a/parser/src/parser-options.spec.js
+++ b/parser/src/parser-options.spec.js
@@ -29,7 +29,6 @@ npc: what do you want to talk about?
                 content: {
                   type: 'content',
                   content: [
-                    { type: 'line', value: 'Life', speaker: 'speaker' },
                     { type: 'line', value: 'I want to talk about life!', speaker: 'player', },
                     { type: 'line', value: 'Well! That\'s too complicated...', speaker: 'npc', },
                   ],
@@ -42,7 +41,6 @@ npc: what do you want to talk about?
                 content: {
                   type: 'content',
                   content: [
-                    { type: 'line', value: 'Everything else...', tags: [ 'some_tag', ] },
                     { type: 'line', value: 'What about everything else?', speaker: 'player', },
                     { type: 'line', value: 'I don\'t have time for this...', speaker: 'npc', },
                   ],
@@ -83,7 +81,6 @@ npc: what do you want to talk about?
                 content: {
                   type: 'content',
                   content: [
-                    { type: 'line', value: 'Life' },
                     { type: 'line', value: 'I want to talk about life!', speaker: 'player', },
                   ],
                 },
@@ -95,7 +92,6 @@ npc: what do you want to talk about?
                 content: {
                   type: 'content',
                   content: [
-                    { type: 'line', value: 'Everything else...', tags: [ 'some_tag', ] },
                     { type: 'line', value: 'What about everything else?', speaker: 'player', },
                   ],
                 },
@@ -135,7 +131,6 @@ npc: what do you want to talk about?
                 content: {
                   type: 'content',
                   content: [
-                    { type: 'line', value: 'Life' },
                     { type: 'line', value: 'I want to talk about life!', speaker: 'player', },
                   ],
                 },
@@ -147,7 +142,6 @@ npc: what do you want to talk about?
                 content: {
                   type: 'content',
                   content: [
-                    { type: 'line', value: 'Everything else...', tags: [ 'some_tag', ] },
                     { type: 'line', value: 'What about everything else?', speaker: 'player', },
                   ],
                 },
@@ -164,13 +158,13 @@ npc: what do you want to talk about?
   });
 
 
-  it('define label only text', () => {
+  it('define label to display as content', () => {
     const result = parse(`
 npc: what do you want to talk about?
-* [Life]
+*= Life
   player: I want to talk about life!
   npc: Well! That's too complicated...
-* [Everything else... #some_tag]
+*= Everything else... #some_tag
   player: What about everything else?
   npc: I don't have time for this...
 `);
@@ -190,6 +184,7 @@ npc: what do you want to talk about?
                 content: {
                   type: 'content',
                   content: [
+                    { type: 'line', value: 'Life' },
                     { type: 'line', value: 'I want to talk about life!', speaker: 'player', },
                     { type: 'line', value: 'Well! That\'s too complicated...', speaker: 'npc', },
                   ],
@@ -202,6 +197,7 @@ npc: what do you want to talk about?
                 content: {
                   type: 'content',
                   content: [
+                    { type: 'line', value: 'Everything else...', tags: ['some_tag'], },
                     { type: 'line', value: 'What about everything else?', speaker: 'player', },
                     { type: 'line', value: 'I don\'t have time for this...', speaker: 'npc', },
                   ],
@@ -287,7 +283,6 @@ spk: second try
                 content: {
                   type: 'content',
                   content: [
-                    { type: 'line', value: 'life' },
                     { type: 'line', value: 'I want to talk about life!', speaker: 'player', },
                     { type: 'line', value: 'Well! That\'s too complicated...', speaker: 'npc', },
                   ],
@@ -307,7 +302,6 @@ spk: second try
                 content: {
                   type: 'content',
                   content: [
-                    { type: 'line', value: 'life' },
                     { type: 'line', value: 'Well! That\'s too complicated...', speaker: 'npc', },
                   ],
                 },
@@ -349,7 +343,6 @@ spk: second try
                 content: {
                   type: 'content',
                   content: [
-                    { type: 'line', value: 'life' },
                     { type: 'line', value: 'I want to talk about life!', speaker: 'player', },
                   ],
                 },
@@ -367,7 +360,6 @@ spk: second try
                 content: {
                   type: 'content',
                   content: [
-                    { type: 'line', value: 'universe' },
                     { type: 'line', value: 'I want to talk about the universe!', speaker: 'player', },
                   ],
                 },
@@ -385,8 +377,8 @@ spk: second try
 
   it('ensures options ending worked', () => {
     const result = parse(`
-* yes
-* no
+*= yes
+*= no
 
 { some_check } maybe
 `);
@@ -437,8 +429,8 @@ spk: second try
 
   it('ensures option item ending worked', () => {
     const result = parse(`
-* yes { set yes = true }
-* [no]
+*= yes { set yes = true }
+* no
   no
 `);
     const expected = {
@@ -486,8 +478,8 @@ spk: second try
 
   it('options with blocks both sides', () => {
     const result = parse(`
-* { what } yes { set yes = true }
-* {set no = true} [no] { when something }
+*= { what } yes { set yes = true }
+* {set no = true} no { when something }
   no
 `);
     const expected = {
@@ -559,11 +551,11 @@ spk: second try
 
   it('options with multiple blocks on same side', () => {
     const result = parse(`
-* yes { when what } { set yes = true }
-* no {set no = true} { when something }
-* { when what } { set yes = true } yes
-* {set no = true} { when something } no
-* {set yes = true} { when yes } yes { set one_more = true }
+*= yes { when what } { set yes = true }
+*= no {set no = true} { when something }
+*= { when what } { set yes = true } yes
+*= {set no = true} { when something } no
+*= {set yes = true} { when yes } yes { set one_more = true }
 `);
     const expected = {
       type: 'document',

--- a/parser/src/parser-variations.spec.js
+++ b/parser/src/parser-variations.spec.js
@@ -126,15 +126,15 @@ describe('variations', () => {
   it('variations with options', () => {
     const result = parse(`
 (
-  - * works?
+  - *= works?
     yes
-  * [yep?]
+  * yep?
     yes
   - nice
   -
-    * works?
+    *= works?
       yes
-    * [yep?]
+    * yep?
       yes
 )
 `);

--- a/parser/src/parser.js
+++ b/parser/src/parser.js
@@ -343,24 +343,24 @@ export default function parse(doc) {
     consume([TOKENS.OPTION, TOKENS.STICKY_OPTION, TOKENS.FALLBACK_OPTION])
     const type = optionType[currentToken.token];
 
-    const acceptableNext = [TOKENS.SPEAKER, TOKENS.TEXT, TOKENS.INDENT, TOKENS.SQR_BRACKET_OPEN, TOKENS.BRACE_OPEN];
+    const acceptableNext = [TOKENS.SPEAKER, TOKENS.TEXT, TOKENS.INDENT, TOKENS.ASSIGN, TOKENS.BRACE_OPEN];
     let lines = [];
     let mainItem;
-    let useFirstLineAsDisplayOnly = false;
+    let includeLabelAsContent = false;
     let root;
     let wrapper;
 
     consume(acceptableNext);
 
+    if (currentToken.token === TOKENS.ASSIGN) {
+      includeLabelAsContent = true;
+      consume(acceptableNext);
+    }
+
     if (currentToken.token === TOKENS.BRACE_OPEN) {
       const block = NestedLogicBlocks();
       root = block.root;
       wrapper = block.wrapper;
-      consume(acceptableNext);
-    }
-
-    if (currentToken.token === TOKENS.SQR_BRACKET_OPEN) {
-      useFirstLineAsDisplayOnly = true;
       consume(acceptableNext);
     }
 
@@ -370,9 +370,7 @@ export default function parse(doc) {
         isMultilineEnabled = false;
         mainItem = Line();
         isMultilineEnabled = true;
-        if (useFirstLineAsDisplayOnly) {
-          consume([TOKENS.SQR_BRACKET_CLOSE]);
-        } else {
+        if (includeLabelAsContent) {
           lines.push(mainItem);
         }
 

--- a/parser/test/samples/all_features.clyde
+++ b/parser/test/samples/all_features.clyde
@@ -8,30 +8,30 @@ I come to show you this line with id $SCENE_1_LINE002
 NPC: This is a dialogue with speaker and id $SCENE_1_LINE001
 player: This is a line with another speaker
 
-* this is the first topic
+*= this is the first topic
   NPC: just a normal line inside the topic #sad #happy #some_tag
   player: another line inside the first topic
-* the second topic
+*= the second topic
   player: a line in the second topic, with speaker defined.
 
 "Those are the topics available:"
-* another topic
+*= another topic
   player: line inside a topic
   NPC: another line inside a topic
   a line without speaker inside the topic
   a line with id inside the topic $this_is_an_id
   <-
-* one more topic
+*= one more topic
   speaker: love is all you need
   <-
-* this is a topic pointing to another block
+*= this is a topic pointing to another block
   -> another_block
-+ this is a sticky topic, with redirect to the beginning of the topics block
++= this is a sticky topic, with redirect to the beginning of the topics block
   just a line
   <-
 
 == another_block
-* straight to the topic
+*= straight to the topic
   player: Go, johnny go.
 <-
 

--- a/parser/test/samples/blocks.clyde
+++ b/parser/test/samples/blocks.clyde
@@ -3,11 +3,11 @@
 == initial_dialogue
 <> intro
 
-* [Life]
+* Life
   -> about_life
-* [The universe]
+* The universe
   -> about_universe
-* [Everything else...]
+* Everything else...
   -> about_everything_else
 
 == intro

--- a/parser/test/samples/diverts.clyde
+++ b/parser/test/samples/diverts.clyde
@@ -3,13 +3,13 @@
 == initial_dialog
 npc: what do you want to talk about?
 
-* [Life]
+* Life
   -> about_life <-
-* [The universe]
+* The universe
   -> about_universe <-
-* [Everything else...]
+* Everything else...
   -> about_everything_else <-
-* [Goodbye!]
+* Goodbye!
   -> goodbye <-
 
 -> END

--- a/parser/test/samples/nesting.clyde
+++ b/parser/test/samples/nesting.clyde
@@ -1,23 +1,23 @@
 -- nesting
 
 npc: what do you want to talk about?
-* [Life]
+* Life
   player: I want to talk about life!
-    * [nested life]
+    * nested life
       npc: Well! That's too complicated...
-* [The universe]
+* The universe
   (
       - player: I want to talk about the universe!
       - npc: That's too complex!
    )
-* [Everything else...]
+* Everything else...
   (
       -
         option 1
         player: What about everything else?
-        * nested option 1
+        *= nested option 1
           yep
-        * nested option 2
+        *= nested option 2
           nope
       -
         option 2
@@ -25,7 +25,7 @@ npc: what do you want to talk about?
   )
   ( cycle
       -
-        * nested option 1
-        * nested option 2
+        *= nested option 1
+        *= nested option 2
       - option 2
   )

--- a/parser/test/samples/options.clyde
+++ b/parser/test/samples/options.clyde
@@ -1,44 +1,44 @@
 -- Options
 
 npc: what do you want to talk about?
-* [Life]
+* Life
   player: I want to talk about life!
   npc: Well! That's too complicated...
-* [The universe]
+* The universe
   player: I want to talk about the universe!
   npc: That's too complex!
-* [Everything else... #some_tag]
+* Everything else... #some_tag
   player: What about everything else?
   npc: I don't have time for this...
 
 -- example of option with description
 
 What's in your mind? #test
-  * [Nothing]
+  * Nothing
     npc: That's a hard state to achieve.
-  * [Everything]
+  * Everything
     npc: You should try to empty it.
 
 
 speaker: What's in your mind? $abc
-  * [Nothing $abc123]
+  * Nothing $abc123
     npc: That's a hard state to achieve.
-  + [Anything $abc123]
+  + Anything $abc123
     npc: That's a hard state to achieve.
-  > [What? $abc123]
+  > What? $abc123
     npc: Never mind.
 
 speaker: What's in your mind?
-  * [Nothing $abc123]
+  * Nothing $abc123
     npc: That's a hard state to achieve.
 
 
 What's in your mind? $abc
-  + [Anything $abc123 #some_other_tag]
+  + Anything $abc123 #some_other_tag
     npc: That's a hard state to achieve.
 
 
 "speaker: >> What's in your mind? $id:abc"
-  * [Nothing]
+  * Nothing
     npc: That's a hard state to achieve.
 

--- a/parser/test/samples/tab_indentation.clyde
+++ b/parser/test/samples/tab_indentation.clyde
@@ -1,19 +1,19 @@
 
 npc: what do you want to talk about?
 
-* [Life]
+* Life
 	player: I want to talk about life!
 	npc: Well! That's too complicated...
-* [The universe]
+* The universe
 	player: I want to talk about the universe!
 	npc: That's too complex!
-* [Everything else...]
+* Everything else...
 	player: What about everything else?
 	npc: I don't have time for this...
 
 What's in your mind?
-	* [Nothing]
+	* Nothing
 		npc: That's a hard state to achieve.
-	* [Everything]
+	* Everything
 		npc: You should try to empty it.
 

--- a/parser/test/samples/variables.clyde
+++ b/parser/test/samples/variables.clyde
@@ -31,13 +31,13 @@ hey you { set a -= 4, b=1, c = "hello" }
 
 { set hp = 5 }
 
-* { hp < 40 } [Life] { set s = false }
+* { hp < 40 } Life { set s = false }
   player: I want to talk about life! {set x = true }
   npc: Well! That's too complicated...
-* [The universe]
+* The universe
   player: I want to talk about the universe!
   npc: That's too complex! { set last_talk = "universe" }
-* {first_time && hp > 10} [Everything else...]
+* {first_time && hp > 10} Everything else...
   {hp > 20 || count == 0} player: What about everything else?
   npc: I don't have time for this...
 


### PR DESCRIPTION
As suggested on https://github.com/viniciusgerevini/godot-clyde-dialogue/issues/11

This is a breaking change. Changed options default behaviour to not include first line. As per feedback and analysis, this seems to be the most sensible behaviour.

- Options won´t print first line as before.
- Brackets (`[` `]`) used for display-only options are not supported anymore.
- To reproduce previous behaviour, options should contain the new display-option symbol (`=`)

Here is a sample on how to fix your dialogues for this new version:

Old way:
```
+ This will be displayed
* This will be displayed
> This will be displayed

+ [This won't be displayed]
  some text...
* [This won't be displayed]
  some text...
> [This won't be displayed]
  some text...
```
New way:
```
+= This will be displayed
*= This will be displayed
>= This will be displayed

+ This won't be displayed
  some text...
* This won't be displayed
  some text...
> This won't be displayed
  some text...
```


