### PR TITLE
id suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Check [LANGUAGE.md](./LANGUAGE.md) for latest documentation.
 
+## 2.1.0 (2022-07-02)
+
+### Added
+
+Id Suffixes: `dialogue line $id&some_var&some_var2`.
+
+Suffixes can help with dialogue localization and alternatives. Example:
+
+dictionary:
+```
+LINE_1;Hello, my friend!
+LINE_1&F;Hello, sister!
+LINE_1&M;Hello, brother!
+```
+Dialogue:
+```
+Hello, my friend! $LINE_1&player_pronoun
+```
+In this case, if the `player_pronoun` variable is set as M, `Hello, brother!` is returned.
+When F, `Hello, sister!` is returned. And when not set, the default LINE_1 `Hello, my friend!` is returned.
+
 ## 2.0.0 (2021-11-21)
 
 ### Breaking Changes

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -183,6 +183,37 @@ Output:
 
 IDs are useful for localisation, where you can organise your translations in files with key values (json, csv) and use them to replace dialogue lines with their translated equivalents.
 
+#### ID suffixes
+
+Append `&` + `[A-Za-z0-9_]` to a line id to set suffixes.
+
+Id Suffixes aim to improve translations and dynamic lines. They allow you to use
+different keys from a dictionary based on values from variables in runtime.
+
+Here is an example. For the given dialogue:
+```
+Hello, sister! $line001&player_pronoun
+```
+
+If the variable `player_pronoun` is set as `F`, the translation lookup will happen in this order: `line001&F`, `line001` and then it falls back to the default line. Multiple suffixes can be set by chaining the variables: `$line001&variable_1&variable_2`.
+
+This can also be used to simplify dialogue files. If you have a dictionary like this:
+```
+LINE_001;Hello, friend.
+LINE_001&F;Hello, sister.
+LINE_001&M;Hello, brother.
+```
+You could change your dialogue from this:
+```
+Hello, sister.  $LINE_001 { when pronoun is "F" }
+Hello, brother. $LINE_002 { when pronoun is "M" }
+Hello, friend.  $LINE_003 { when not pronoun }
+```
+To this:
+```
+Hello, sister. $LINE_001&pronoun
+```
+
 ### Tags
 
 Use `#` + `[A-Za-z0-9_]` to set line tags:

--- a/interpreter/CHANGELOG.md
+++ b/interpreter/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Added
+
+- Implemented support for id suffixes. `dialogue line $id&variable_1&variable_2`.
+
 ## 3.0.2 (2022-07-04)
 
 ### Fixed
+
 - Update parser to fix inconsistencies with logic blocks in tab indented files.
 
 ## 3.0.1 (2022-07-04)

--- a/interpreter/src/interpreter.spec.ts
+++ b/interpreter/src/interpreter.spec.ts
@@ -165,7 +165,7 @@ hello %someVar%
     });
   });
 
-  describe('translation', () => {
+  describe('Translation', () => {
     it('define dictionary and bring keys from it when available', () => {
       const dictionary = {
         abc: 'this is a replacement',
@@ -281,6 +281,23 @@ first topics $abc&suffix1
       const dialogue = Interpreter(content);
 
       expect(() => dialogue.getContent()).toThrow(/Unkown node type "SomeUnkownNode"/);
+    });
+  });
+
+  describe('Interpreter Options', () => {
+
+    it('sets id suffixes separators', () => {
+      const dictionary = {
+        'abc': 'should not use this one. Without suffix',
+        'abc&P': 'should not use this one. Default suffix separator.',
+        'abc__P': 'use this one',
+      };
+      const content = parse('This should be replaced $abc&suffix_1');
+
+      const dialogue = Interpreter(content, undefined, dictionary, { idSuffixLookupSeparator: '__' });
+      dialogue.setVariable("suffix_1", "P");
+
+      expect((dialogue.getContent() as DialogueLine).text).toEqual('use this one');
     });
   });
 });

--- a/interpreter/src/interpreter.ts
+++ b/interpreter/src/interpreter.ts
@@ -139,11 +139,24 @@ export interface InterpreterInstance {
   start(blockName?: string): void;
 }
 
+interface InterpreterOptions {
+  // Separator used between suffixes when looking translation keys up.
+  // default: &
+  idSuffixLookupSeparator: string;
+}
+
 /**
  * Clyde Interpreter
  */
-export function Interpreter(clydeDoc: ClydeDocumentRoot, data?: any, dictionary: Dictionary  = {}): InterpreterInstance {
+export function Interpreter(
+  clydeDoc: ClydeDocumentRoot,
+  data?: any, dictionary: Dictionary  = {},
+  interpreterOptions?: InterpreterOptions
+): InterpreterInstance {
   const doc: ClydeDocumentRoot & WorkingNode = clydeDoc;
+  const intOptions: InterpreterOptions = {
+    idSuffixLookupSeparator: interpreterOptions?.idSuffixLookupSeparator || '&'
+  };
   let textDictionary = dictionary;
   const anchors: {[name: string]: any} = {
   };
@@ -503,7 +516,13 @@ export function Interpreter(clydeDoc: ClydeDocumentRoot, data?: any, dictionary:
 
   const translateText = (text: string, id: string | undefined, idSuffixes?: string[]) => {
     if (idSuffixes) {
-      let identifier = `${id}&${idSuffixes.map(p => mem.getVariable(p)).filter(Boolean).join('&')}`;
+      const suffixes = idSuffixes.map(
+        p => mem.getVariable(p)
+      )
+      .filter(Boolean)
+      .join(intOptions.idSuffixLookupSeparator);
+
+      const identifier = `${id}${intOptions.idSuffixLookupSeparator}${suffixes}`;
       if (textDictionary[identifier]) {
         return textDictionary[identifier];
       }

--- a/interpreter/src/interpreter.ts
+++ b/interpreter/src/interpreter.ts
@@ -359,9 +359,9 @@ export function Interpreter(clydeDoc: ClydeDocumentRoot, data?: any, dictionary:
       speaker: optionsNode.speaker,
       id: optionsNode.id,
       tags: optionsNode.tags,
-      name: replaceVariables(translateText(optionsNode.name as string, optionsNode.id)),
-      options: options.map((t: ActionContentNode | OptionNode) => t.type === 'action_content' ? t.content : t).map((t) => ({
-        label: replaceVariables(translateText(t.name, t.id)),
+      name: replaceVariables(translateText(optionsNode.name as string, optionsNode.id, optionsNode.id_suffixes)),
+      options: options.map((t: ActionContentNode | OptionNode) => t.type === 'action_content' ? t.content : t).map((t: OptionNode) => ({
+        label: replaceVariables(translateText(t.name!, t.id, t.id_suffixes)),
         speaker: t.speaker,
         tags: t.tags,
         id: t.id
@@ -411,7 +411,7 @@ export function Interpreter(clydeDoc: ClydeDocumentRoot, data?: any, dictionary:
       tags: lineNode.tags,
       id: lineNode.id,
       speaker: lineNode.speaker,
-      text: replaceVariables(translateText(lineNode.value, lineNode.id))
+      text: replaceVariables(translateText(lineNode.value, lineNode.id, lineNode.id_suffixes))
     };
   }
 
@@ -501,10 +501,18 @@ export function Interpreter(clydeDoc: ClydeDocumentRoot, data?: any, dictionary:
     return option;
   };
 
-  const translateText = (text: string, id: string | undefined) => {
+  const translateText = (text: string, id: string | undefined, idSuffixes?: string[]) => {
+    if (idSuffixes) {
+      let identifier = `${id}&${idSuffixes.map(p => mem.getVariable(p)).filter(Boolean).join('&')}`;
+      if (textDictionary[identifier]) {
+        return textDictionary[identifier];
+      }
+    }
+
     if (id && textDictionary[id]) {
       return textDictionary[id];
     }
+
     return text;
   };
 

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Added
+
+- Implemented support for id suffixes. `dialogue line $id&variable_1&variable_2`.
+
 ## 2.1.2 (2022-07-04)
 
 ### Fixed
+
 - Fix inconsistencies with logic blocks in tab indented files.
 
 ## 2.1.1 (2022-07-04)

--- a/parser/src/lexer.spec.ts
+++ b/parser/src/lexer.spec.ts
@@ -339,6 +339,31 @@ speaker1: this is something $123`).getAll();
     ]);
   });
 
+  it('id sufixes', () => {
+    const tokens = tokenize(`
+speaker1: this is something $123&var1
+* this is another thing $abc&var1&var2
+*= hello $a1b2&var1 #tag`).getAll();
+    expect(tokens).toEqual([
+      { token: TOKENS.SPEAKER, value: 'speaker1', line: 1, column: 0 },
+      { token: TOKENS.TEXT, value: 'this is something', line: 1, column: 10 },
+      { token: TOKENS.LINE_ID, value: '123', line: 1, column: 28 },
+      { token: TOKENS.ID_SUFFIX, value: 'var1', line: 1, column: 32 },
+      { token: TOKENS.OPTION, line: 2, column: 0 },
+      { token: TOKENS.TEXT, value: 'this is another thing', line: 2, column: 2 },
+      { token: TOKENS.LINE_ID, value: 'abc', line: 2, column: 24 },
+      { token: TOKENS.ID_SUFFIX, value: 'var1', line: 2, column: 28 },
+      { token: TOKENS.ID_SUFFIX, value: 'var2', line: 2, column: 33 },
+      { token: TOKENS.OPTION, line: 3, column: 0 },
+      { token: TOKENS.ASSIGN, line: 3, column: 1 },
+      { token: TOKENS.TEXT, value: 'hello', line: 3, column: 3 },
+      { token: TOKENS.LINE_ID, value: 'a1b2', line: 3, column: 9 },
+      { token: TOKENS.ID_SUFFIX, value: 'var1', line: 3, column: 14 },
+      { token: TOKENS.TAG, value: 'tag', line: 3, column: 20 },
+      { token: TOKENS.EOF, line: 3, column: 24 },
+    ]);
+  });
+
   it('tags', () => {
     const tokens = tokenize(`
 this is something #hello #happy #something_else

--- a/parser/src/lexer.ts
+++ b/parser/src/lexer.ts
@@ -11,6 +11,7 @@ export const TOKENS = {
   SPEAKER: 'SPEAKER',
   LINE_ID: 'LINE_ID',
   TAG: 'TAG',
+  ID_SUFFIX: 'ID_SUFFIX',
   BLOCK: 'BLOCK',
   DIVERT: 'DIVERT',
   DIVERT_PARENT: 'DIVERT_PARENT',
@@ -72,6 +73,7 @@ const tokenFriendlyHint = {
   [TOKENS.SPEAKER]: '<speaker name>:',
   [TOKENS.LINE_ID]: '$id',
   [TOKENS.TAG]: '#tag',
+  [TOKENS.ID_SUFFIX]: '&id_suffix',
   [TOKENS.BLOCK]: '== <block name>',
   [TOKENS.DIVERT]: '-> <target name>',
   [TOKENS.DIVERT_PARENT]: '<-',
@@ -328,7 +330,30 @@ export function tokenize(input: string): TokenList {
       position += 1;
       column += 1;
     }
-    return { token: TOKENS.LINE_ID, line, column: initialColumn, value: values.join('') };
+    const idToken = { token: TOKENS.LINE_ID, line, column: initialColumn, value: values.join('') };
+
+    const tokens = [idToken];
+
+    while (input[position] === '&') {
+      tokens.push(handleIdSuffix());
+    }
+
+    return tokens;
+  };
+
+  const handleIdSuffix = () => {
+    const initialColumn = column;
+    let values = [];
+    position += 1;
+    column += 1;
+
+    while (input[position] && input[position].match(/[A-Z|a-z|0-9|_]/)) {
+      values.push(input[position]);
+      position += 1;
+      column += 1;
+    }
+
+    return { token: TOKENS.ID_SUFFIX, line, column: initialColumn, value: values.join('') };
   };
 
   const handleTag = () => {

--- a/parser/src/nodes.ts
+++ b/parser/src/nodes.ts
@@ -20,7 +20,8 @@ export class LineNode {
     public value: string,
     public speaker?: string,
     public id?: string,
-    public tags?: string[]
+    public tags?: string[],
+    public id_suffixes?: string[]
   ) {};
 }
 
@@ -32,7 +33,8 @@ export class OptionsNode {
     public name?: string,
     public id?: string,
     public speaker?: string,
-    public tags?: string[]
+    public tags?: string[],
+    public id_suffixes?: string[]
   ) {};
 }
 
@@ -45,7 +47,8 @@ export class OptionNode {
     public name?: string,
     public id?: string,
     public speaker?: string,
-    public tags?: string[]
+    public tags?: string[],
+    public id_suffixes?: string[]
   ) {};
 }
 

--- a/parser/src/parser-lines.spec.ts
+++ b/parser/src/parser-lines.spec.ts
@@ -27,7 +27,7 @@ describe('parse: lines', () => {
     const result = parse(`
 jules: say what one more time! $first #yelling #mad
 just text
-just id $another
+just id $another&var1&var2
 just tags #tag
 speaker: just speaker
 id last #tag #another_tag $some_id
@@ -39,7 +39,7 @@ id last #tag #another_tag $some_id
         content: [
           { type: 'line', value: 'say what one more time!', id: 'first', speaker: 'jules', tags: [ 'yelling', 'mad' ] },
           { type: 'line', value: 'just text' },
-          { type: 'line', value: 'just id', id: 'another' },
+          { type: 'line', value: 'just id', id: 'another', id_suffixes: [ 'var1', 'var2'] },
           { type: 'line', value: 'just tags', tags: [ 'tag' ] },
           { type: 'line', value: 'just speaker', speaker: 'speaker' },
           { type: 'line', value: 'id last', id: 'some_id', tags: [ 'tag', 'another_tag' ] },
@@ -54,8 +54,8 @@ id last #tag #another_tag $some_id
   it('parse multiline', () => {
     const result = parse(`
 jules: say what one more time!
-     Just say it $some_id #tag
-hello! $id_on_first_line #and_tags
+     Just say it $some_id&suffix #tag
+hello! $id_on_first_line&suffix #and_tags
     Just talking.
 `);
     const expected = {
@@ -63,8 +63,8 @@ hello! $id_on_first_line #and_tags
       content: [{
         type: 'content',
         content: [
-          { type: 'line', value: 'say what one more time! Just say it', id: 'some_id', speaker: 'jules', tags: [ 'tag' ] },
-          { type: 'line', value: 'hello! Just talking.', id: 'id_on_first_line', tags: [ 'and_tags' ] },
+          { type: 'line', value: 'say what one more time! Just say it', id: 'some_id', speaker: 'jules', tags: [ 'tag' ], id_suffixes: ['suffix'] },
+          { type: 'line', value: 'hello! Just talking.', id: 'id_on_first_line', tags: [ 'and_tags' ], id_suffixes: ['suffix'] },
         ]
       }],
       blocks: []

--- a/parser/src/parser-options.spec.ts
+++ b/parser/src/parser-options.spec.ts
@@ -11,6 +11,8 @@ npc: what do you want to talk about?
 * Everything else... #some_tag
   player: What about everything else?
   npc: I don't have time for this...
+* one more thing $abc&whatever
+  npc: one
 `);
     const expected = {
       type: 'document',
@@ -46,6 +48,19 @@ npc: what do you want to talk about?
                   ],
                 },
                 tags: [ 'some_tag', ],
+              },
+              {
+                type: 'option',
+                name: 'one more thing',
+                mode: 'once',
+                content: {
+                  type: 'content',
+                  content: [
+                    { type: 'line', value: 'one', speaker: 'npc', },
+                  ],
+                },
+                id: 'abc',
+                id_suffixes: [ 'whatever' ],
               },
             ],
           },
@@ -220,7 +235,8 @@ npc: what do you want to talk about?
   life
   player: I want to talk about life!
   npc: Well! That's too complicated...
-
+*
+  the universe #tag $id&suffix
 `);
     const expected = {
       type: 'document',
@@ -243,6 +259,20 @@ npc: what do you want to talk about?
                   ],
                 },
               },
+              {
+                type: 'option',
+                mode: 'once',
+                name: 'the universe',
+                id: 'id',
+                tags: ['tag'],
+                id_suffixes: ['suffix'],
+                content: {
+                  type: 'content',
+                  content: [
+                    { type: 'line', value: 'the universe', id: 'id', tags: ['tag'], id_suffixes: ['suffix'] },
+                  ],
+                },
+              },
             ],
           },
         ],
@@ -255,7 +285,7 @@ npc: what do you want to talk about?
 
   it('use previous line as label', () => {
     const result = parse(`
-spk: this line will be the label $some_id #some_tag
+spk: this line will be the label $some_id&some_suffix #some_tag
   * life
     player: I want to talk about life!
     npc: Well! That's too complicated...
@@ -274,6 +304,7 @@ spk: second try
             speaker: 'spk',
             id: 'some_id',
             tags: ['some_tag'],
+            id_suffixes: ['some_suffix'],
             name: 'this line will be the label',
             content: [
               {


### PR DESCRIPTION
Id suffixes aim to improve translations and dynamic lines. They allow you to use
different keys from a dictionary based on values from variables in runtime.

Here is an example. For the given dialogue:
```
Hello, sister! $line001&player_pronoun
```

If the variable `player_pronoun` is set as `F`, the translation lookup will happen in this order: `line001&F`, `line001` and then it falls back to the default line. Multiple suffixes can be set by chaining the variables: `$line001&variable_1&variable_2`.

This can also be used to simplify dialogue files. If you have a dictionary like this:
```
LINE_001;Hello, friend.
LINE_001&F;Hello, sister.
LINE_001&M;Hello, brother.
```
You could change your dialogue from this:
```
Hello, sister.  $LINE_001 { when pronoun is "F" }
Hello, brother. $LINE_002 { when pronoun is "M" }
Hello, friend.  $LINE_003 { when not pronoun }
```
To this:
```
Hello, sister. $LINE_001&pronoun
```