### PR TITLE
return object on end of dialogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Check [LANGUAGE.md](./LANGUAGE.md) for latest documentation.
 
+## Unreleased
+
+### Added
+
+- Assignment initializer operator `?=`. It only assigns if variable was not set before.
+
+### Changed
+
+- Return End of Dialogue object instead of undefined. `{ type: 'end' }`.
+
+
 ## 2.1.0 (2022-07-02)
 
 ### Added

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -77,7 +77,10 @@ The main methods used are `getContent()` and `choose(int)`.
 }
 ```
 
-**Null / undefined**: This means the dialogue has reached an end.
+**End of Dialogue**: This means the dialogue has reached an end.
+```javascript
+{ type: 'end' }
+```
 
 When `options` are available, you can choose one of them by passing its index to the dialogue object. Option's index starts from 0:
 

--- a/editor/src/interpreter/DialogueEntry.tsx
+++ b/editor/src/interpreter/DialogueEntry.tsx
@@ -63,7 +63,7 @@ export default function DialogueEntry(props) {
     showMetadata
   } = props;
 
-  if (line === undefined) {
+  if (line.type === "end") {
     return <InfoBubble>DIALOGUE ENDED</InfoBubble>;
   }
 

--- a/editor/src/interpreter/Interpreter.test.tsx
+++ b/editor/src/interpreter/Interpreter.test.tsx
@@ -43,7 +43,7 @@ describe('Interpreter component', () => {
   it('shows end message when dialogue has ended', () => {
     const addDialogueLineStub = jest.fn();
     const content = 'Hello!\n';
-    const timeline = [undefined];
+    const timeline = [{ type: "end" }];
     const { getByText, getByLabelText } = render(
       <Interpreter content={content} timeline={timeline} addDialogueLine={addDialogueLineStub}/>
     );
@@ -528,7 +528,7 @@ third line
             addDialogueLine={addDialogueLineStub}/>
       );
 
-      fireEvent.click(getByLabelText(/Forward untill next choice/i));
+      fireEvent.click(getByLabelText(/Forward until next choice/i));
 
       expect(addDialogueLineStub).toHaveBeenCalledTimes(4);
       expect(addDialogueLineStub).toHaveBeenLastCalledWith({ type: 'options', options: [{ label: 'yes' }]});
@@ -556,10 +556,10 @@ third line
             addDialogueLine={addDialogueLineStub}/>
       );
 
-      fireEvent.click(getByLabelText(/Forward untill next choice/i));
+      fireEvent.click(getByLabelText(/Forward until next choice/i));
 
       expect(addDialogueLineStub).toHaveBeenCalledTimes(4);
-      expect(addDialogueLineStub).toHaveBeenLastCalledWith(undefined);
+      expect(addDialogueLineStub).toHaveBeenLastCalledWith({ type: 'end' });
     });
 
     it('run poltergeist mode: choose all options', () => {
@@ -598,7 +598,7 @@ this is the end
       fireEvent.click(getByLabelText(/Execute Poltergeist mode \(auto anwser\)/i));
 
       expect(addDialogueLineStub).toHaveBeenCalledTimes(11);
-      expect(addDialogueLineStub).toHaveBeenLastCalledWith(undefined);
+      expect(addDialogueLineStub).toHaveBeenLastCalledWith({ type: 'end' });
       expect(chooseOptionStub).toHaveBeenCalledTimes(3);
       expect(timeline[timeline.length - 2]).toEqual({ type: 'line', text: 'this is the end'});
     });

--- a/editor/src/interpreter/InterpreterTimeline.tsx
+++ b/editor/src/interpreter/InterpreterTimeline.tsx
@@ -23,11 +23,11 @@ export default function InterpreterTimeline(props) {
 
   const next = () => {
     const line = dialogue.getContent();
-    if (line && line.type === 'options' && timeline.length > 0 && timeline[timeline.length - 1].type === 'options') {
+    if (line.type === 'options' && timeline.length > 0 && timeline[timeline.length - 1].type === 'options') {
       return;
     }
 
-    if (!line && !timeline[timeline.length - 1]) {
+    if (line.type === 'end' && !timeline[timeline.length - 1]) {
       return;
     }
     addDialogueLine(line);

--- a/editor/src/interpreter/InterpreterTimeline.tsx
+++ b/editor/src/interpreter/InterpreterTimeline.tsx
@@ -27,7 +27,7 @@ export default function InterpreterTimeline(props) {
       return;
     }
 
-    if (line.type === 'end' && !timeline[timeline.length - 1]) {
+    if (line.type === 'end' && timeline[timeline.length - 1]?.type === 'end') {
       return;
     }
     addDialogueLine(line);

--- a/editor/src/interpreter/InterpreterToolbar.tsx
+++ b/editor/src/interpreter/InterpreterToolbar.tsx
@@ -92,7 +92,7 @@ export default function InterpreterToolbar(properties) {
     const line = dialogue.getContent();
     addDialogueLine(line);
 
-    if (!line || line.type === 'options') {
+    if (line.type === 'options') {
       return line;
     }
 

--- a/editor/src/interpreter/InterpreterToolbar.tsx
+++ b/editor/src/interpreter/InterpreterToolbar.tsx
@@ -92,7 +92,7 @@ export default function InterpreterToolbar(properties) {
     const line = dialogue.getContent();
     addDialogueLine(line);
 
-    if (line.type === 'options') {
+    if (line.type === 'end' || line.type === 'options') {
       return line;
     }
 
@@ -102,7 +102,7 @@ export default function InterpreterToolbar(properties) {
   const poltergeist = () => {
     const optionList = forwardToNextOption();
 
-    if (!optionList) {
+    if (optionList.type == "end") {
       return;
     }
 
@@ -126,7 +126,7 @@ export default function InterpreterToolbar(properties) {
       <BlockList document={doc} currentBlock={currentBlock} onBlockSelected={selectBlock}/>
       <FontAwesomeIcon icon={faRedoAlt} title="Restart dialogue" onClick={restart}/>
 
-      <FontAwesomeIcon icon={faFastForward} title="Forward untill next choice" onClick={forwardToNextOption}/>
+      <FontAwesomeIcon icon={faFastForward} title="Forward until next choice" onClick={forwardToNextOption}/>
 
       <FontAwesomeIcon icon={faGhost} title="Execute Poltergeist mode (auto anwser)" onClick={poltergeist}/>
 

--- a/interpreter/CHANGELOG.md
+++ b/interpreter/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Increment assigment now have default values. i.e. If you run `set a += 1` when `a` is not set, it will be set to 1. Before it would break because value was null.
+- Return End of Dialogue object instead of undefined
 
 
 ## 3.1.0 (2022-08-25)

--- a/interpreter/src/interpreter-alternatives.spec.ts
+++ b/interpreter/src/interpreter-alternatives.spec.ts
@@ -59,7 +59,7 @@ describe("Interpreter: variations", () => {
     const content = parse(`( shuffle sequence\n - Hello!\n - Hi!\n - Hey!\n)\nend\n`);
     const dialogue = Interpreter(content);
 
-    let usedOptions = [];
+    let usedOptions: string[] = [];
     for (let _i in [0, 1, 2]) {
       dialogue.start();
       const option = (dialogue.getContent() as DialogueLine).text
@@ -75,7 +75,7 @@ describe("Interpreter: variations", () => {
     const content = parse(`( shuffle once\n - Hello!\n - Hi!\n - Hey!\n)\nend\n`);
     const dialogue = Interpreter(content);
 
-    let usedOptions = [];
+    let usedOptions: string[] = [];
     for (let _i in [0, 1, 2]) {
       dialogue.start();
       const option = (dialogue.getContent() as DialogueLine).text
@@ -90,8 +90,8 @@ describe("Interpreter: variations", () => {
     const content = parse(`( ${mode}\n - Hello!\n - Hi!\n - Hey!\n)\nend\n`);
     const dialogue = Interpreter(content);
 
-    let usedOptions = [];
-    let secondRunUsedOptions = [];
+    let usedOptions: string[] = [];
+    let secondRunUsedOptions: string[] = [];
     for (let _i in [0, 1, 2]) {
       dialogue.start();
       const option = (dialogue.getContent() as DialogueLine).text
@@ -130,8 +130,8 @@ describe("Interpreter: variations", () => {
     const content = parse(`( shuffle cycle\n - { not alreadyRun } Hello! { set alreadyRun = true}\n - Hi!\n - Hey!\n)\nend\n`);
     const dialogue = Interpreter(content);
 
-    let usedOptions = [];
-    let secondRunUsedOptions = [];
+    let usedOptions: string[] = [];
+    let secondRunUsedOptions: string[] = [];
     for (let _i in [0, 1, 2]) {
       dialogue.start();
       usedOptions.push((dialogue.getContent() as DialogueLine).text);

--- a/interpreter/src/interpreter-blocks-diverts.spec.ts
+++ b/interpreter/src/interpreter-blocks-diverts.spec.ts
@@ -9,7 +9,7 @@ describe("Interpreter: blocks and diverts", () => {
 
       expect(dialogue.getContent()).toEqual({ type: 'line', text: 'Hello!' });
       expect(dialogue.getContent()).toEqual({ type: 'line', text: 'Hi there.' });
-      expect(dialogue.getContent()).toEqual(undefined);
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
     });
 
     it('execute block by name', () => {
@@ -19,18 +19,18 @@ describe("Interpreter: blocks and diverts", () => {
       dialogue.start('some_block');
 
       expect(dialogue.getContent()).toEqual({ type: 'line', text: 'Hello from the block!' });
-      expect(dialogue.getContent()).toEqual(undefined);
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
 
       dialogue.start('some_other_block');
 
       expect(dialogue.getContent()).toEqual({ type: 'line', text: 'Hello from the other block!' });
-      expect(dialogue.getContent()).toEqual(undefined);
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
 
       dialogue.start();
 
       expect(dialogue.getContent()).toEqual({ type: 'line', text: 'Hello!' });
       expect(dialogue.getContent()).toEqual({ type: 'line', text: 'Hi there.' });
-      expect(dialogue.getContent()).toEqual(undefined);
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
     });
   });
 
@@ -53,7 +53,7 @@ this is another block
       expect((dialogue.getContent() as DialogueLine).text).toEqual('Hello!');
       expect((dialogue.getContent() as DialogueLine).text).toEqual("Let's go to another block");
       expect((dialogue.getContent() as DialogueLine).text).toEqual('this is another block');
-      expect(dialogue.getContent()).toEqual(undefined);
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
     });
 
     it('divert back to parent', () => {
@@ -76,7 +76,7 @@ this is another block
       expect((dialogue.getContent() as DialogueLine).text).toEqual("Let's go to another block");
       expect((dialogue.getContent() as DialogueLine).text).toEqual('this is another block');
       expect((dialogue.getContent() as DialogueLine).text).toEqual('this line should be called after block');
-      expect(dialogue.getContent()).toEqual(undefined);
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
     });
 
     it('divert from block to options list', () => {
@@ -153,8 +153,8 @@ this will never be seeing
       dialogue.start();
 
       expect((dialogue.getContent() as DialogueLine).text).toEqual('Hello!');
-      expect(dialogue.getContent()).toEqual(undefined);
-      expect(dialogue.getContent()).toEqual(undefined);
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
     });
 
     it('does not fail when divert to parent in the root node', () => {
@@ -167,7 +167,7 @@ Hello!
       dialogue.start();
 
       expect((dialogue.getContent() as DialogueLine).text).toEqual('Hello!');
-      expect(dialogue.getContent()).toEqual(undefined);
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
     });
   });
 });

--- a/interpreter/src/interpreter-options.spec.ts
+++ b/interpreter/src/interpreter-options.spec.ts
@@ -23,7 +23,7 @@ describe("Interpreter: options", () => {
     dialogue.choose(1)
     expect(dialogue.getContent()).toEqual({ type: 'line',  text: 'ba' });
     expect(dialogue.getContent()).toEqual({ type: 'line',  text: 'bb' });
-    expect(dialogue.getContent()).toEqual(undefined);
+    expect(dialogue.getContent()).toEqual({ type: 'end' });
 
     dialogue.start();
     expect(dialogue.getContent()).toEqual({ type: 'options', name: 'hello', speaker: 'speaker', tags: [ 'name_tag' ], options: [{ label: 'a' }, { label: 'c' } ] });
@@ -31,7 +31,7 @@ describe("Interpreter: options", () => {
 
     expect(dialogue.getContent()).toEqual({ type: 'line', text: 'ca' });
     expect(dialogue.getContent()).toEqual({ type: 'line', text: 'cb' });
-    expect(dialogue.getContent()).toEqual(undefined);
+    expect(dialogue.getContent()).toEqual({ type: 'end' });
 
     dialogue.start();
     expect(dialogue.getContent()).toEqual({ type: 'options', name: 'hello', speaker: 'speaker', tags: [ 'name_tag' ], options: [{ label: 'a' }, { label: 'c' } ] });
@@ -39,7 +39,7 @@ describe("Interpreter: options", () => {
     dialogue.choose(0)
     expect(dialogue.getContent()).toEqual({ type: 'line', text: 'aa' });
     expect(dialogue.getContent()).toEqual({ type: 'line', text: 'ab' });
-    expect(dialogue.getContent()).toEqual(undefined);
+    expect(dialogue.getContent()).toEqual({ type: 'end' });
   });
 
   it('use fallback option when others not available', () => {
@@ -64,24 +64,24 @@ describe("Interpreter: options", () => {
     expect(dialogue.getContent()).toEqual({ type: 'options', name: 'hello', speaker: 'speaker', options: [{ label: 'a' },{ label: 'b' }, { label: 'c 3 left' } ] });
     dialogue.choose(1);
     expect(dialogue.getContent()).toEqual({ type: 'line',  text: 'b 2' });
-    expect(dialogue.getContent()).toEqual(undefined);
+    expect(dialogue.getContent()).toEqual({ type: 'end' });
 
     dialogue.start();
     expect(dialogue.getContent()).toEqual({ type: 'options', name: 'hello', speaker: 'speaker', options: [{ label: 'a' }, { label: 'c 2 left' } ] });
     dialogue.choose(0);
 
     expect(dialogue.getContent()).toEqual({ type: 'line', text: 'a 1' });
-    expect(dialogue.getContent()).toEqual(undefined);
+    expect(dialogue.getContent()).toEqual({ type: 'end' });
 
     dialogue.start();
     expect(dialogue.getContent()).toEqual({ type: 'options', name: 'hello', speaker: 'speaker', options: [{ label: 'c 1 left' } ] });
 
     dialogue.choose(0);
     expect(dialogue.getContent()).toEqual({ type: 'line', text: 'c 0' });
-    expect(dialogue.getContent()).toEqual(undefined);
+    expect(dialogue.getContent()).toEqual({ type: 'end' });
 
     dialogue.start();
-    expect(dialogue.getContent()).toEqual(undefined);
+    expect(dialogue.getContent()).toEqual({ type: 'end' });
   });
 
   it('use special variable OPTIONS_COUNT as condition', () => {
@@ -109,7 +109,7 @@ hello %OPTIONS_COUNT%
 
     dialogue.choose(0)
     expect(dialogue.getContent()).toEqual({ type: 'line', text: 'nope' });
-    expect(dialogue.getContent()).toEqual(undefined);
+    expect(dialogue.getContent()).toEqual({ type: 'end' });
   });
 
   it('fails when trying to select option when in wrong state', () => {

--- a/interpreter/src/interpreter.spec.ts
+++ b/interpreter/src/interpreter.spec.ts
@@ -156,12 +156,12 @@ hello %someVar%
   });
 
   describe('End of dialogue', () => {
-    it('get undefined when not more lines left', () => {
+    it('get end return when not more lines left', () => {
       const content = parse('Hi!\n');
       const dialogue = Interpreter(content);
       expect(dialogue.getContent()).toEqual({ type: 'line', text: 'Hi!' });
-      expect(dialogue.getContent()).toBe(undefined);
-      expect(dialogue.getContent()).toBe(undefined);
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
+      expect(dialogue.getContent()).toEqual({ type: 'end' });
     });
   });
 


### PR DESCRIPTION
This is a breaking change. On end of dialogue instead of returning undefined the interpreter will return `{ type: "end" }`.