### PR TITLE
Change block identifier for persising options and variations

### DIFF
--- a/interpreter/CHANGELOG.md
+++ b/interpreter/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Breaking changes
+
+- Dialogues now return an object when ended. This impacts how you determined if the dialogue has ended.
+- Changed identifier for blocks when persisting so changing block order does not impact already saved files. This will impact variations and single use options on all existing save files.
+
 ### Added
 
 - Assignment initializer operator `?=`. It only assigns if variable was not set before.
@@ -12,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Increment assigment now have default values. i.e. If you run `set a += 1` when `a` is not set, it will be set to 1. Before it would break because value was null.
 - Return End of Dialogue object instead of undefined
+
+### Fixed
+
+- Changing block order in file does not impact persisted options and variations anymore.
 
 
 ## 3.1.0 (2022-08-25)

--- a/interpreter/src/interpreter.spec.ts
+++ b/interpreter/src/interpreter.spec.ts
@@ -153,6 +153,44 @@ hello %someVar%
       dialogue.clearData();
       expect((dialogue.getContent() as DialogueLine).text).toEqual('hello ');
     });
+
+    it("changing block order does not impact options persistence", () => {
+      const block1 = `
+== block_1
+* option 1
+  line 1
+* option 2
+  line 2
+`;
+      const block2 = `
+== block_2
+* option 1
+  line 1
+* option 2
+  line 2
+`;
+
+      const content = parse(block1 + block2);
+      const invertedContent = parse(block2 + block1);
+
+      const dialogue = Interpreter(content);
+      dialogue.start("block_1")
+      dialogue.getContent();
+      dialogue.choose(0);
+
+      const data = dialogue.getData();
+
+      const invertedDialogue = Interpreter(invertedContent);
+      invertedDialogue.loadData(data);
+      invertedDialogue.start("block_1")
+      const block1Options = invertedDialogue.getContent();
+      invertedDialogue.start("block_2")
+      const block2Options = invertedDialogue.getContent();
+
+
+      expect(block1Options).toEqual({ type: 'options', options: [{ label: 'option 2' }] });
+      expect(block2Options).toEqual({ type: 'options', options: [{ label: 'option 1' }, { label: 'option 2' }] });
+    });
   });
 
   describe('End of dialogue', () => {

--- a/interpreter/src/interpreter.ts
+++ b/interpreter/src/interpreter.ts
@@ -23,7 +23,7 @@ type StackItem = {
 };
 
 type WorkingNode = {
-  _index?: number,
+  _index?: string,
 }
 
 type WorkingActionContentNode = ActionContentNode & { mode: string };
@@ -174,9 +174,9 @@ export function Interpreter(
   let stack: StackItem[];
   const logic = LogicInterpreter(mem);
 
-  doc._index = 1;
-  doc.blocks.forEach((block: BlockNode & WorkingNode, index: number) => {
-    block._index = index + 2;
+  doc._index = "r";
+  doc.blocks.forEach((block: BlockNode & WorkingNode) => {
+    block._index = `b_${block.name}`;
     anchors[block.name] = block;
   });
 
@@ -234,7 +234,7 @@ export function Interpreter(
     'shuffle': (variations: VariationsNode & WorkingNode, mode = 'cycle' ): number => {
       const SHUFFLE_VISITED_KEY = `${variations._index}_shuffle_visited`;
       const LAST_VISITED_KEY = `${variations._index}_last_index`;
-      let visitedItems: number[] = mem.getInternalVariable(SHUFFLE_VISITED_KEY, []);
+      let visitedItems: string[] = mem.getInternalVariable(SHUFFLE_VISITED_KEY, []);
       const remainingOptions: (ContentNode & WorkingNode)[]  = variations.content.filter((a: ContentNode & WorkingNode) => !visitedItems.includes(a._index!));
 
       if (remainingOptions.length === 0) {
@@ -271,7 +271,7 @@ export function Interpreter(
 
   const handleNextNode = (node: any, fallback?: any) => (nodeHandlers[node.type] || nodeHandlers['error'])(node, fallback);
 
-  const generateIndex = () => (10 * stackHead().current._index) + stackHead().contentIndex;
+  const generateIndex = () => `${stackHead().current._index}_${stackHead().contentIndex}`;
 
   const addToStack = (node: any) => {
     if (stackHead().current !== node) {
@@ -411,7 +411,7 @@ export function Interpreter(
     if (!variations._index) {
       variations._index = generateIndex();
       variations.content.forEach((c: ContentNode & WorkingNode, index: number) => {
-        c._index = generateIndex() * 100 + index;
+        c._index = `${generateIndex()}_${index}`;
       });
     }
 
@@ -507,7 +507,7 @@ export function Interpreter(
 
   const prepareOption = (option: ( WorkingActionContentNode | ConditionalContentNode | OptionNode) & WorkingNode, index: number): any => {
     if (!option._index) {
-      option._index = generateIndex() * 100 + index;
+      option._index = `${generateIndex()}_${index}`;
     }
 
     if (option.type === 'conditional_content') {


### PR DESCRIPTION
Changed identifier for blocks when persisting so changing block order does not impact already saved files. This will impact variations and single use options on all existing save files.

This is a breaking change.
