### PR TITLE
External variable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Check [LANGUAGE.md](./LANGUAGE.md) for latest documentation.
 
-## Unreleased
+## 3.0.0 (Unreleased)
+
+### Breaking changes
+
+- Return End of Dialogue object instead of undefined. `{ type: 'end' }`.
+- Variation `shuffle` will do real randomization with no guarantee all items will be visited.
 
 ### Added
 
 - Assignment initializer operator `?=`. It only assigns if variable was not set before.
 - External variables using `@` prefix. They are not included in the save object, so they are not persisted between runs.
 They are useful when dealing with data that belongs to your game and shouldn't be persisted with the dialogue.
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Check [LANGUAGE.md](./LANGUAGE.md) for latest documentation.
 ### Added
 
 - Assignment initializer operator `?=`. It only assigns if variable was not set before.
+- External variables using `@` prefix. They are not included in the save object, so they are not persisted between runs.
+They are useful when dealing with data that belongs to your game and shouldn't be persisted with the dialogue.
 
 ### Changed
 

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -42,6 +42,14 @@ dialogue.setVariable(name, value);
 // Get value of variables set in the dialogue
 dialogue.getVariable(name);
 
+// Set external variable to be used by the dialogue
+// External variables can be accessed using the `@` prefix and
+// are not included in the save object, so they are not persisted between runs.
+dialogue.setExternalVariable(name, value);
+
+// Get value of external variables set in the dialogue
+dialogue.getExternalVariable(name);
+
 // Load a dictionary with translations.
 // when returning a line with line id defined, it looks first in this object
 // for translation before returning the value. Useful for localisation.
@@ -809,7 +817,7 @@ There are three types of logic blocks: assignments, conditions, and triggers.
 
 ### Assignments
 
-Besides setting external variables using the interpreter method, you can set variables internally with assignment blocks. Assignment blocks need to start with the `set` keyword. Here are some examples:
+Besides setting variables using the interpreter method, you can set variables internally with assignment blocks. Assignment blocks need to start with the `set` keyword. Here are some examples:
 
 ```
 -- standalone
@@ -947,6 +955,34 @@ Hello, %playerName%! Long time no see.
 This should print `Hello, Vini! Long time no see!`
 
 This can be used with variables defined internally or externally.
+
+### External variables
+
+External variables can be accessed using the `@` prefix and are not included in the save object, so they are not persisted between runs.
+
+They are useful when dealing with data that belongs to your game and shouldn't be persisted with the dialogue. They can be set and changed in the dialogue
+like this:
+
+```
+{ set @hp = 10 }
+```
+
+To set them from your game you can use one of these methods:
+
+```
+dialogue.setExternalVariable("npc_name", "Vincent"); // this variable will be accessible as @npc_name
+// or
+dialogue.setVariable("@npc_name", "Vincent");
+```
+To retrieve it back:
+
+```
+dialogue.getExternalVariable("npc_name");
+// or
+dialogue.getVariable("@npc_name");
+```
+
+External variables do not trigger the `variable_changed` event. They trigger the `external_variable_changed` event instead.
 
 ### Special variables
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Breaking changes
+
+- `shuffle` variations are really random now.
+
+### Changed
+
+- Bump interpreter major version. `shuffle` variations change. External var support.
+
 ## 2.2.0 (2022-08-25)
 
 ### Added

--- a/cli/src/interpreter.ts
+++ b/cli/src/interpreter.ts
@@ -6,6 +6,7 @@ import {
   DialogueLine,
   DialogueOption,
   DialogueOptions,
+  DialogueEnd,
   Dictionary,
   EventType,
   Interpreter,
@@ -62,8 +63,8 @@ const inputHandlers = (dialogue: InterpreterInstance, args: InterpreterCliArgs, 
     }
   };
 
-  const printContent = (content: DialogueLine | DialogueOptions | undefined) => {
-    if (content === undefined) {
+  const printContent = (content: DialogueLine | DialogueOptions | DialogueEnd) => {
+    if (content.type === "end") {
       console.log('-- END');
       if (argv.debug) {
         printDebugInfo(events);

--- a/interpreter/CHANGELOG.md
+++ b/interpreter/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Assignment initializer operator `?=`. It only assigns if variable was not set before.
+- External variable support. Implemented `set_external_variable` and `get_external_variable`.
 
 ### Changed
 

--- a/interpreter/src/events.ts
+++ b/interpreter/src/events.ts
@@ -1,5 +1,6 @@
 export enum EventType {
   VARIABLE_CHANGED = 'variable_changed',
+  EXTERNAL_VARIABLE_CHANGED = 'external_variable_changed',
   EVENT_TRIGGERED = 'event_triggered'
 };
 
@@ -14,6 +15,7 @@ type ListenerList = { [event: string]: Function[] };
 export function Events(): EventsInstance {
   const listeners: ListenerList = {
     [EventType.VARIABLE_CHANGED]: [],
+    [EventType.EXTERNAL_VARIABLE_CHANGED]: [],
     [EventType.EVENT_TRIGGERED]: [],
   };
 

--- a/interpreter/src/index.ts
+++ b/interpreter/src/index.ts
@@ -2,6 +2,7 @@ export {
   DialogueLine,
   DialogueOption,
   DialogueOptions,
+  DialogueEnd,
   Dictionary,
   Interpreter,
   InterpreterInstance,

--- a/interpreter/src/interpreter-variables.spec.ts
+++ b/interpreter/src/interpreter-variables.spec.ts
@@ -136,5 +136,31 @@ mod assignment { set a %= 2 }
 
     expect(dialogue.getContent()).toEqual({ type: 'line', text: 'var  here' });
   });
+
+  it('set external variable via dialogue', () => {
+    const content = parse('lets set a variable {set @something="the"}\nthis is %@something% variable\n');
+    const dialogue = Interpreter(content);
+
+    expect((dialogue.getContent() as DialogueLine).text).toEqual('lets set a variable');
+    expect((dialogue.getContent() as DialogueLine).text).toEqual('this is the variable');
+  });
+
+  it('set external variable externally', () => {
+    const content = parse('vars %@id% %@name% %id%\nvars %@id% %@name% %id%\n');
+    const dialogue = Interpreter(content);
+
+    dialogue.setExternalVariable('id', 'some_id');
+    dialogue.setExternalVariable('name', 'some name');
+    dialogue.setVariable('id', 'internal_id');
+    dialogue.setVariable('some_internal_var', 'internal_id');
+
+    expect(dialogue.getExternalVariable('id')).toBe("some_id");
+    expect(dialogue.getContent()).toEqual({ type: 'line', text: 'vars some_id some name internal_id' });
+
+    dialogue.setExternalVariable('id', 'some other id');
+
+    expect(dialogue.getContent()).toEqual({ type: 'line', text: 'vars some other id some name internal_id' });
+    expect(dialogue.getExternalVariable("some_internal_var")).toEqual(undefined);
+  });
 });
 

--- a/interpreter/src/interpreter.spec.ts
+++ b/interpreter/src/interpreter.spec.ts
@@ -37,6 +37,20 @@ describe("Interpreter", () => {
       dialogue.getContent()
     });
 
+    it('trigger event on external variable changed', (done) => {
+      const content = parse('Hi!{ set @something = 123 }\n');
+      const dialogue = Interpreter(content);
+
+      dialogue.setExternalVariable('something', 456);
+
+      dialogue.on(EventType.EXTERNAL_VARIABLE_CHANGED, (data: any) => {
+        expect(data).toEqual({ name:'something', value: 123, previousValue: 456 });
+        done();
+      });
+
+      dialogue.getContent()
+    });
+
     it('remove listener', (done) => {
       const content = parse('Hi!{ set something = 123 }\n');
       const dialogue = Interpreter(content);
@@ -309,6 +323,22 @@ first topics $abc&suffix1
         const secondOptions = dialogue.getContent() as DialogueOptions;
         expect(secondOptions.options[0].label).toEqual('simple key with suffix 1 and 2');
       });
+    });
+
+    it('external variables should not be included in final data', () =>{
+      const content = parse(`
+Hi!{ set @someVar = 1, someOtherVar = 2 }
+`);
+      const dialogue = Interpreter(content);
+
+      dialogue.setExternalVariable("yet_another_var", 3);
+
+      expect((dialogue.getContent() as DialogueLine).text).toEqual('Hi!');
+      expect(dialogue.getData()).toEqual(expect.objectContaining({
+        variables: {
+          someOtherVar: 2,
+        }
+      }));
     });
   });
 

--- a/interpreter/src/interpreter.ts
+++ b/interpreter/src/interpreter.ts
@@ -1,5 +1,5 @@
 import { LogicInterpreter } from'./logic_interpreter';
-import { Memory, InternalMemory } from './memory';
+import { Memory, DialogueData } from './memory';
 import { Events, EventType } from './events';
 import {
   ClydeDocumentRoot,
@@ -90,14 +90,14 @@ export interface InterpreterInstance {
    *
    * @return data
    */
-  getData(): InternalMemory;
+  getData(): DialogueData;
 
   /**
    * Load internal data
    *
    * @param data
    */
-  loadData(data: InternalMemory): void;
+  loadData(data: DialogueData): void;
 
   /**
    * Clear all internal data
@@ -139,6 +139,21 @@ export interface InterpreterInstance {
    * @return variable value
    */
   getVariable(name: string): any;
+
+  /**
+   * set external variable
+   *
+   * @param name - External variable name
+   * @param value - Value
+   */
+  setExternalVariable(name: string, value: any): void;
+
+  /**
+   * Return external variable value
+   * @param name - External variable name
+   * @return variable value
+   */
+  getExternalVariable(name: string): any;
 
   /**
    * Start dialogue from the begining
@@ -557,7 +572,7 @@ export function Interpreter(
 
   const replaceVariables = (text: string) => {
     if (text) {
-      (text.match(/\%([A-z0-9]*)\%/g) || [])
+      (text.match(/\%([A-z0-9@]*)\%/g) || [])
         .map(match => {
           const name = match.replace(/\%/g, '');
           let value: any;
@@ -582,11 +597,11 @@ export function Interpreter(
       listeners.removeListener(eventName, callback);
     },
 
-    getData(): InternalMemory {
+    getData(): DialogueData {
       return mem.getAll();
     },
 
-    loadData(data: InternalMemory) {
+    loadData(data: DialogueData) {
       mem.load(data);
     },
 
@@ -612,6 +627,14 @@ export function Interpreter(
 
     getVariable(name: string): any {
       return mem.getVariable(name);
+    },
+
+    setExternalVariable(name: string, value: any): void {
+      mem.setExternalVariable(name, value);
+    },
+
+    getExternalVariable(name: string): any {
+      return mem.getExternalVariable(name);
     },
 
     start(blockName?: string): void {

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Assignment initializer operator `?=`. It only assigns if variable was not set before.
+- Define and access external variable by using `@` prefix.
 
 ### Changed
 

--- a/parser/src/lexer.spec.ts
+++ b/parser/src/lexer.spec.ts
@@ -537,6 +537,7 @@ hello
 { variable == false }
 { variable == "s1" }
 { variable == null }
+{ @global_variable }
 
 `).getAll();
     expect(tokens).toEqual([
@@ -706,7 +707,13 @@ hello
       { token: TOKENS.BRACE_CLOSE, line: 23, column: 19, },
       { token: TOKENS.LINE_BREAK, line: 23, column: 20, },
 
-      { token: TOKENS.EOF, line: 25, column: 0 },
+      { token: TOKENS.LINE_BREAK, line: 24, column: 0,  },
+      { token: TOKENS.BRACE_OPEN, line: 24, column: 0, },
+      { token: TOKENS.IDENTIFIER, value: '@global_variable', line: 24, column: 2, },
+      { token: TOKENS.BRACE_CLOSE, line: 24, column: 19, },
+      { token: TOKENS.LINE_BREAK, line: 24, column: 20, },
+
+      { token: TOKENS.EOF, line: 26, column: 0 },
 
     ]);
   });

--- a/parser/src/lexer.ts
+++ b/parser/src/lexer.ts
@@ -498,6 +498,12 @@ export function tokenize(input: string): TokenList {
     const initialColumn = column;
     let values = '';
 
+    if (input[position] == "@") {
+      values += input[position];
+      position += 1;
+      column += 1;
+    }
+
     while (input[position] && input[position].match(/[A-Z|a-z|0-9|_]/)) {
       values += input[position];
       position += 1;
@@ -698,7 +704,7 @@ export function tokenize(input: string): TokenList {
       return handleLogicNumber();
     }
 
-    if (input[position].match(/[A-Za-z]/)) {
+    if (input[position].match(/[A-Za-z@]/)) {
       return handleLogicIdentifier();
     }
   };


### PR DESCRIPTION
External variables using `@` prefix. They are not included in the save object, so they are not persisted between runs.
They are useful when dealing with data that belongs to your game and shouldn't be persisted with the dialogue.

Externally
```
dialogue.setExternalVariable(name, value);

dialogue.getExternalVariable(name);
```
in dialogue:
```
Hello %@name%! { set @hp += 10 }
```