### PR TITLE
Provide a way to set speaker to multiple lines at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Check [LANGUAGE.md](./LANGUAGE.md) for latest documentation.
 
+## 3.0.1 (2024-10-01)
+
+### Added
+
+- Allow defining speaker to multiple lines at once by indenting them.
+i.e
+```
+Vinny:
+    Multiple lines can be set with same speaker.
+    You just need to indent them after the speaker line.
+    Grouping lines also work this way
+        by indenting the line further.
+```
+
 ## 3.0.0 (2024-02-14)
 
 ### Breaking changes

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -172,6 +172,27 @@ Output:
 { type: 'line', speaker: 'Harry Potter', text: "I'm a what?" }
 ```
 
+When defining multiple lines with same speaker, you can set the same speaker for all lines
+by indenting them after the speaker:
+
+```
+Vinny:
+    Multiple lines can be set with same speaker.
+    You just need to indent them after the speaker line.
+    Grouping lines also work this way
+        by indenting the line further.
+```
+
+Output:
+```javascript
+// get content
+{ type: 'line', speaker: 'Vinny', text: 'Multiple lines can be set with same speaker.' }
+// get content
+{ type: 'line', speaker: 'Vinny', text: 'You just need to indent them after the speaker line.' }
+// get content
+{ type: 'line', speaker: 'Vinny', text: 'Grouping lines also work this way by indenting the line further.' }
+```
+
 ### Line ID
 
 Use `$` + `[A-Za-z0-9_]` to set a line id:

--- a/parser/src/parser-lines.spec.ts
+++ b/parser/src/parser-lines.spec.ts
@@ -105,7 +105,8 @@ jules:
     Still third line
   This is conditional { some_var }
   Fourth line $fourth
-Line with no speaker
+vincent:
+  Another one
 `);
     const expected = {
       type: 'document',
@@ -121,7 +122,7 @@ Line with no speaker
             content: { type: "line", value: "This is conditional", speaker: 'jules' }
           },
           { type: 'line', value: 'Fourth line', id: 'fourth', speaker: 'jules' },
-          { type: 'line', value: 'Line with no speaker' },
+          { type: 'line', value: 'Another one', speaker: 'vincent' },
         ]
       }],
       blocks: []

--- a/parser/src/parser-lines.spec.ts
+++ b/parser/src/parser-lines.spec.ts
@@ -96,6 +96,40 @@ Just talking."
     expect(result).toEqual(expected);
   });
 
+  it('parse lines grouped by speaker', () => {
+    const result = parse(`
+jules:
+  First line $first #yelling #mad
+  Second line $second #sec
+  Third line w multi line $third #t
+    Still third line
+  This is conditional { some_var }
+  Fourth line $fourth
+Line with no speaker
+`);
+    const expected = {
+      type: 'document',
+      content: [{
+        type: 'content',
+        content: [
+          { type: 'line', value: 'First line', id: 'first', speaker: 'jules', tags: [ 'yelling', 'mad' ] },
+          { type: 'line', value: 'Second line', id: 'second', speaker: 'jules', tags: [ 'sec' ] },
+          { type: 'line', value: 'Third line w multi line Still third line', id: 'third', speaker: 'jules', tags: [ 't' ] },
+          {
+            type: "conditional_content",
+            conditions: { type: "variable", name: "some_var" },
+            content: { type: "line", value: "This is conditional", speaker: 'jules' }
+          },
+          { type: 'line', value: 'Fourth line', id: 'fourth', speaker: 'jules' },
+          { type: 'line', value: 'Line with no speaker' },
+        ]
+      }],
+      blocks: []
+    };
+    expect(result).toEqual(expected);
+  });
+
+
   it('throws error when empty string in quotes', () => {
     expect(() => parse(`speaker: ""`)).toThrow(/Unexpected token "EOF" on line 1 column 12. Expected text /);
   });

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -262,7 +262,9 @@ export default function parse(doc: string): ClydeDocumentRoot {
       }
     }
 
-    consume([TOKENS.DEDENT]);
+    if (peek([TOKENS.DEDENT])) {
+      consume([TOKENS.DEDENT]);
+    }
     return lines;
   };
 

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -185,6 +185,12 @@ export default function parse(doc: string): ClydeDocumentRoot {
       case TOKENS.SPEAKER:
       case TOKENS.TEXT:
         consume([ TOKENS.SPEAKER, TOKENS.TEXT ]);
+
+        if (currentToken.token == TOKENS.SPEAKER && peek([TOKENS.INDENT])) {
+          lines = LinesWithSpeaker();
+          break;
+        }
+
         const line = DialogueLine();
         if (peek([TOKENS.BRACE_OPEN])) {
           consume([TOKENS.BRACE_OPEN]);
@@ -235,6 +241,29 @@ export default function parse(doc: string): ClydeDocumentRoot {
       case TOKENS.TEXT:
         return TextLine();
     }
+  };
+
+  const LinesWithSpeaker = (): LineNode[] => {
+    const speakerToken = currentToken;
+    const lines = [];
+
+    consume([TOKENS.INDENT]);
+
+    while (peek([TOKENS.DEDENT, TOKENS.EOF]) == null) {
+      consume([TOKENS.TEXT]);
+      const line = TextLine();
+      line.speaker = speakerToken.value;
+
+      if (peek([TOKENS.BRACE_OPEN])) {
+        consume([TOKENS.BRACE_OPEN]);
+        lines.push(LineWithAction(line));
+      } else {
+        lines.push(line);
+      }
+    }
+
+    consume([TOKENS.DEDENT]);
+    return lines;
   };
 
   const LineWithSpeaker = (): LineNode => {


### PR DESCRIPTION
Allow defining speaker to multiple lines at once by indenting them.
i.e
```clyde
Vinny:
    Multiple lines can be set with same speaker.
    You just need to indent them after the speaker line.
    Grouping lines also work this way
        by indenting the line further.
```

```javascript
// get content
{ type: 'line', speaker: 'Vinny', text: 'Multiple lines can be set with same speaker.' }
// get content
{ type: 'line', speaker: 'Vinny', text: 'You just need to indent them after the speaker line.' }
// get content
{ type: 'line', speaker: 'Vinny', text: 'Grouping lines also work this way by indenting the line further.' }
```